### PR TITLE
feat: trigger a portfolio snapshot after a trade execution

### DIFF
--- a/src/services/trade-simulator.service.ts
+++ b/src/services/trade-simulator.service.ts
@@ -4,6 +4,7 @@ import { BalanceManager } from './balance-manager.service';
 import { PriceTracker } from './price-tracker.service';
 import { repositories } from '../database';
 import { config, features } from '../config';
+import { services } from './index';
 
 // Define an interface for chain options
 interface ChainOptions {
@@ -230,6 +231,13 @@ export class TradeSimulator {
                 New ${fromToken} Balance: ${await this.balanceManager.getBalance(teamId, fromToken)}
                 New ${toToken} Balance: ${await this.balanceManager.getBalance(teamId, toToken)}
             `);
+
+      // Trigger a portfolio snapshot after successful trade execution
+      // We run this asynchronously without awaiting to avoid delaying the trade response
+      services.competitionManager.takePortfolioSnapshots(competitionId).catch(error => {
+        console.error(`[TradeSimulator] Error taking portfolio snapshot after trade: ${error.message}`);
+      });
+      console.log(`[TradeSimulator] Portfolio snapshot triggered for competition ${competitionId} after trade`);
 
       return {
         success: true,


### PR DESCRIPTION
#Summary
Added Automatic Portfolio Snapshots After Trade Execution

##Overview

This PR implements automatic portfolio snapshots after each successful trade. The change modifies the TradeSimulator service to trigger a portfolio snapshot asynchronously immediately after a trade is executed, capturing the updated portfolio state without delaying the trade response. This ensures portfolio values are more frequently and accurately tracked throughout trading activity, providing better visibility into portfolio changes over time.

##Testing

Original e2e trading tests (and remainder of e2e testing suite) continue to work. Console logs validate that portfolio snapshotting is indeed occurring.