### PR TITLE
feat: finish team registration, disqualify, reinstate, and competition admin routes

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1053,7 +1053,8 @@ Get the leaderboard for the active competition or a specific competition
       "teamName": "string",
       "portfolioValue": 0
     }
-  ]
+  ],
+  "disqualifiedTeamsFiltered": true
 }
 ```
 
@@ -1089,6 +1090,7 @@ Status Code **200**
 |»» teamId|string|false|none|Team ID|
 |»» teamName|string|false|none|Team name|
 |»» portfolioValue|number|false|none|Current portfolio value in USD|
+|» disqualifiedTeamsFiltered|boolean|false|none|Indicates whether any disqualified teams were filtered out of the leaderboard results|
 
 #### Enumerated Values
 
@@ -2039,6 +2041,182 @@ Status Code **200**
 |status|pending|
 |status|active|
 |status|completed|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+BearerAuth
+</aside>
+
+## Disqualify a team
+
+> Code samples
+
+```javascript
+const inputBody = '{
+  "reason": "Violated competition rules by using external API"
+}';
+const headers = {
+  'Content-Type':'application/json',
+  'Accept':'application/json',
+  'Authorization':'Bearer {access-token}'
+};
+
+fetch('http://localhost:3000/api/admin/teams/{teamId}/disqualify',
+{
+  method: 'POST',
+  body: inputBody,
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+`POST /api/admin/teams/{teamId}/disqualify`
+
+Disqualify a team from the competition. The team will no longer be able to perform any actions.
+
+> Body parameter
+
+```json
+{
+  "reason": "Violated competition rules by using external API"
+}
+```
+
+<h3 id="disqualify-a-team-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|teamId|path|string|true|ID of the team to disqualify|
+|body|body|object|true|none|
+|» reason|body|string|true|Reason for disqualification|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "success": true,
+  "message": "string",
+  "team": {
+    "id": "string",
+    "name": "string",
+    "disqualified": true,
+    "disqualificationReason": "string",
+    "disqualificationDate": "2019-08-24T14:15:22Z"
+  }
+}
+```
+
+<h3 id="disqualify-a-team-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Team disqualified successfully|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Missing required parameters|None|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized - Admin authentication required|None|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Cannot disqualify admin accounts|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Team not found|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error|None|
+
+<h3 id="disqualify-a-team-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» success|boolean|false|none|Operation success status|
+|» message|string|false|none|Success message|
+|» team|object|false|none|none|
+|»» id|string|false|none|Team ID|
+|»» name|string|false|none|Team name|
+|»» disqualified|boolean|false|none|Disqualification status|
+|»» disqualificationReason|string|false|none|Reason for disqualification|
+|»» disqualificationDate|string(date-time)|false|none|Date of disqualification|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+BearerAuth
+</aside>
+
+## Reinstate a team
+
+> Code samples
+
+```javascript
+
+const headers = {
+  'Accept':'application/json',
+  'Authorization':'Bearer {access-token}'
+};
+
+fetch('http://localhost:3000/api/admin/teams/{teamId}/reinstate',
+{
+  method: 'POST',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+`POST /api/admin/teams/{teamId}/reinstate`
+
+Reinstate a previously disqualified team, allowing them to participate in the competition again.
+
+<h3 id="reinstate-a-team-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|teamId|path|string|true|ID of the team to reinstate|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "success": true,
+  "message": "string",
+  "team": {
+    "id": "string",
+    "name": "string",
+    "disqualified": true
+  }
+}
+```
+
+<h3 id="reinstate-a-team-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Team reinstated successfully|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Team is not currently disqualified|None|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized - Admin authentication required|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Team not found|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error|None|
+
+<h3 id="reinstate-a-team-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» success|boolean|false|none|Operation success status|
+|» message|string|false|none|Success message|
+|» team|object|false|none|none|
+|»» id|string|false|none|Team ID|
+|»» name|string|false|none|Team name|
+|»» disqualified|boolean|false|none|Disqualification status (should be false)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1229,7 +1229,7 @@ fetch('http://localhost:3000/api/competition/rules',
 
 `GET /api/competition/rules`
 
-Get the rules for all competitions
+Get the rules, rate limits, and other configuration details for the competition
 
 <h3 id="get-competition-rules-parameters">Parameters</h3>
 
@@ -1251,7 +1251,16 @@ Get the rules for all competitions
     "rateLimits": [
       "string"
     ],
-    "slippageFormula": "string"
+    "availableChains": {
+      "svm": true,
+      "evm": [
+        "string"
+      ]
+    },
+    "slippageFormula": "string",
+    "portfolioSnapshots": {
+      "interval": "string"
+    }
   }
 }
 ```
@@ -1260,8 +1269,10 @@ Get the rules for all competitions
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Competition rules|Inline|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Competition rules retrieved successfully|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request - No active competition|None|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized - Missing or invalid authentication|None|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Forbidden - Team not participating in the competition|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error|None|
 
 <h3 id="get-competition-rules-responseschema">Response Schema</h3>
@@ -1272,9 +1283,14 @@ Status Code **200**
 |---|---|---|---|---|
 |» success|boolean|false|none|Operation success status|
 |» rules|object|false|none|none|
-|»» tradingRules|[string]|false|none|List of trading rules|
-|»» rateLimits|[string]|false|none|List of rate limits|
-|»» slippageFormula|string|false|none|Formula used to calculate slippage|
+|»» tradingRules|[string]|false|none|List of trading rules for the competition|
+|»» rateLimits|[string]|false|none|Rate limits for API endpoints|
+|»» availableChains|object|false|none|none|
+|»»» svm|boolean|false|none|Whether Solana (SVM) is available|
+|»»» evm|[string]|false|none|List of available EVM chains|
+|»» slippageFormula|string|false|none|Formula used for calculating slippage|
+|»» portfolioSnapshots|object|false|none|none|
+|»»» interval|string|false|none|Interval between portfolio snapshots|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1051,10 +1051,12 @@ Get the leaderboard for the active competition or a specific competition
       "rank": 0,
       "teamId": "string",
       "teamName": "string",
-      "portfolioValue": 0
+      "portfolioValue": 0,
+      "disqualified": true,
+      "disqualificationReason": "string"
     }
   ],
-  "disqualifiedTeamsFiltered": true
+  "hasDisqualifiedTeams": true
 }
 ```
 
@@ -1090,7 +1092,9 @@ Status Code **200**
 |»» teamId|string|false|none|Team ID|
 |»» teamName|string|false|none|Team name|
 |»» portfolioValue|number|false|none|Current portfolio value in USD|
-|» disqualifiedTeamsFiltered|boolean|false|none|Indicates whether any disqualified teams were filtered out of the leaderboard results|
+|»» disqualified|boolean|false|none|Whether the team has been disqualified|
+|»» disqualificationReason|string¦null|false|none|Reason for disqualification if applicable|
+|» hasDisqualifiedTeams|boolean|false|none|Indicates if any teams are disqualified|
 
 #### Enumerated Values
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1631,12 +1631,116 @@ To perform this operation, you must be authenticated by means of one of the foll
 BearerAuth
 </aside>
 
+## Create a competition
+
+> Code samples
+
+```javascript
+const inputBody = '{
+  "name": "Spring 2023 Trading Competition",
+  "description": "A trading competition for the spring semester"
+}';
+const headers = {
+  'Content-Type':'application/json',
+  'Accept':'application/json',
+  'Authorization':'Bearer {access-token}'
+};
+
+fetch('http://localhost:3000/api/admin/competition/create',
+{
+  method: 'POST',
+  body: inputBody,
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+`POST /api/admin/competition/create`
+
+Create a new competition without starting it. It will be in PENDING status and can be started later.
+
+> Body parameter
+
+```json
+{
+  "name": "Spring 2023 Trading Competition",
+  "description": "A trading competition for the spring semester"
+}
+```
+
+<h3 id="create-a-competition-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|object|true|none|
+|» name|body|string|true|Competition name|
+|» description|body|string|false|Competition description|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "success": true,
+  "competition": {
+    "id": "string",
+    "name": "string",
+    "description": "string",
+    "status": "PENDING",
+    "createdAt": "2019-08-24T14:15:22Z"
+  }
+}
+```
+
+<h3 id="create-a-competition-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Competition created successfully|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Missing required parameters|None|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized - Admin authentication required|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error|None|
+
+<h3 id="create-a-competition-responseschema">Response Schema</h3>
+
+Status Code **201**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» success|boolean|false|none|Operation success status|
+|» competition|object|false|none|none|
+|»» id|string|false|none|Competition ID|
+|»» name|string|false|none|Competition name|
+|»» description|string|false|none|Competition description|
+|»» status|string|false|none|Competition status|
+|»» createdAt|string(date-time)|false|none|Competition creation date|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|PENDING|
+|status|ACTIVE|
+|status|COMPLETED|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+BearerAuth
+</aside>
+
 ## Start a competition
 
 > Code samples
 
 ```javascript
 const inputBody = '{
+  "competitionId": "string",
   "name": "Spring 2023 Trading Competition",
   "description": "A trading competition for the spring semester",
   "teamIds": [
@@ -1665,12 +1769,13 @@ fetch('http://localhost:3000/api/admin/competition/start',
 
 `POST /api/admin/competition/start`
 
-Create and start a new trading competition with specified teams
+Start a new or existing competition with specified teams. If competitionId is provided, it will start an existing competition. Otherwise, it will create and start a new one.
 
 > Body parameter
 
 ```json
 {
+  "competitionId": "string",
   "name": "Spring 2023 Trading Competition",
   "description": "A trading competition for the spring semester",
   "teamIds": [
@@ -1684,8 +1789,9 @@ Create and start a new trading competition with specified teams
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
 |body|body|object|true|none|
-|» name|body|string|true|Competition name|
-|» description|body|string|false|Competition description|
+|» competitionId|body|string|false|ID of an existing competition to start. If not provided, a new competition will be created.|
+|» name|body|string|false|Competition name (required when creating a new competition)|
+|» description|body|string|false|Competition description (used when creating a new competition)|
 |» teamIds|body|[string]|true|Array of team IDs to include in the competition|
 
 > Example responses
@@ -1701,7 +1807,7 @@ Create and start a new trading competition with specified teams
     "description": "string",
     "startDate": "2019-08-24T14:15:22Z",
     "endDate": "2019-08-24T14:15:22Z",
-    "status": "pending",
+    "status": "PENDING",
     "teamIds": [
       "string"
     ]
@@ -1716,6 +1822,7 @@ Create and start a new trading competition with specified teams
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Competition started successfully|Inline|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Missing required parameters|None|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized - Admin authentication required|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Competition not found when using competitionId|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error|None|
 
 <h3 id="start-a-competition-responseschema">Response Schema</h3>
@@ -1738,9 +1845,9 @@ Status Code **200**
 
 |Property|Value|
 |---|---|
-|status|pending|
-|status|active|
-|status|completed|
+|status|PENDING|
+|status|ACTIVE|
+|status|COMPLETED|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -1807,7 +1914,7 @@ End an active competition and finalize the results
     "description": "string",
     "startDate": "2019-08-24T14:15:22Z",
     "endDate": "2019-08-24T14:15:22Z",
-    "status": "pending"
+    "status": "PENDING"
   },
   "leaderboard": [
     {
@@ -1850,9 +1957,9 @@ Status Code **200**
 
 |Property|Value|
 |---|---|
-|status|pending|
-|status|active|
-|status|completed|
+|status|PENDING|
+|status|ACTIVE|
+|status|COMPLETED|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -1991,7 +2098,7 @@ Get performance reports and leaderboard for a competition
     "description": "string",
     "startDate": "2019-08-24T14:15:22Z",
     "endDate": "2019-08-24T14:15:22Z",
-    "status": "pending"
+    "status": "PENDING"
   },
   "leaderboard": [
     {
@@ -2038,9 +2145,9 @@ Status Code **200**
 
 |Property|Value|
 |---|---|
-|status|pending|
-|status|active|
-|status|completed|
+|status|PENDING|
+|status|ACTIVE|
+|status|COMPLETED|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1052,11 +1052,11 @@ Get the leaderboard for the active competition or a specific competition
       "teamId": "string",
       "teamName": "string",
       "portfolioValue": 0,
-      "disqualified": true,
-      "disqualificationReason": "string"
+      "active": true,
+      "deactivationReason": "string"
     }
   ],
-  "hasDisqualifiedTeams": true
+  "hasInactiveTeams": true
 }
 ```
 
@@ -1092,9 +1092,9 @@ Status Code **200**
 |»» teamId|string|false|none|Team ID|
 |»» teamName|string|false|none|Team name|
 |»» portfolioValue|number|false|none|Current portfolio value in USD|
-|»» disqualified|boolean|false|none|Whether the team has been disqualified|
-|»» disqualificationReason|string¦null|false|none|Reason for disqualification if applicable|
-|» hasDisqualifiedTeams|boolean|false|none|Indicates if any teams are disqualified|
+|»» active|boolean|false|none|Whether the team is active|
+|»» deactivationReason|string¦null|false|none|Reason for deactivation if applicable|
+|» hasInactiveTeams|boolean|false|none|Indicates if any teams are inactive|
 
 #### Enumerated Values
 
@@ -2179,7 +2179,7 @@ To perform this operation, you must be authenticated by means of one of the foll
 BearerAuth
 </aside>
 
-## Disqualify a team
+## Deactivate a team
 
 > Code samples
 
@@ -2193,7 +2193,7 @@ const headers = {
   'Authorization':'Bearer {access-token}'
 };
 
-fetch('http://localhost:3000/api/admin/teams/{teamId}/disqualify',
+fetch('http://localhost:3000/api/admin/teams/{teamId}/deactivate',
 {
   method: 'POST',
   body: inputBody,
@@ -2207,9 +2207,9 @@ fetch('http://localhost:3000/api/admin/teams/{teamId}/disqualify',
 
 ```
 
-`POST /api/admin/teams/{teamId}/disqualify`
+`POST /api/admin/teams/{teamId}/deactivate`
 
-Disqualify a team from the competition. The team will no longer be able to perform any actions.
+Deactivate a team from the competition. The team will no longer be able to perform any actions.
 
 > Body parameter
 
@@ -2219,13 +2219,13 @@ Disqualify a team from the competition. The team will no longer be able to perfo
 }
 ```
 
-<h3 id="disqualify-a-team-parameters">Parameters</h3>
+<h3 id="deactivate-a-team-parameters">Parameters</h3>
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|teamId|path|string|true|ID of the team to disqualify|
+|teamId|path|string|true|ID of the team to deactivate|
 |body|body|object|true|none|
-|» reason|body|string|true|Reason for disqualification|
+|» reason|body|string|true|Reason for deactivation|
 
 > Example responses
 
@@ -2234,49 +2234,47 @@ Disqualify a team from the competition. The team will no longer be able to perfo
 ```json
 {
   "success": true,
-  "message": "string",
   "team": {
     "id": "string",
     "name": "string",
-    "disqualified": true,
-    "disqualificationReason": "string",
-    "disqualificationDate": "2019-08-24T14:15:22Z"
+    "active": true,
+    "deactivationReason": "string",
+    "deactivationDate": "2019-08-24T14:15:22Z"
   }
 }
 ```
 
-<h3 id="disqualify-a-team-responses">Responses</h3>
+<h3 id="deactivate-a-team-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Team disqualified successfully|Inline|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Team deactivated successfully|Inline|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Missing required parameters|None|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized - Admin authentication required|None|
-|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Cannot disqualify admin accounts|None|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Cannot deactivate admin accounts|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Team not found|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error|None|
 
-<h3 id="disqualify-a-team-responseschema">Response Schema</h3>
+<h3 id="deactivate-a-team-responseschema">Response Schema</h3>
 
 Status Code **200**
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |» success|boolean|false|none|Operation success status|
-|» message|string|false|none|Success message|
 |» team|object|false|none|none|
 |»» id|string|false|none|Team ID|
 |»» name|string|false|none|Team name|
-|»» disqualified|boolean|false|none|Disqualification status|
-|»» disqualificationReason|string|false|none|Reason for disqualification|
-|»» disqualificationDate|string(date-time)|false|none|Date of disqualification|
+|»» active|boolean|false|none|Active status (will be false)|
+|»» deactivationReason|string|false|none|Reason for deactivation|
+|»» deactivationDate|string(date-time)|false|none|Date of deactivation|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
 BearerAuth
 </aside>
 
-## Reinstate a team
+## Reactivate a team
 
 > Code samples
 
@@ -2287,7 +2285,7 @@ const headers = {
   'Authorization':'Bearer {access-token}'
 };
 
-fetch('http://localhost:3000/api/admin/teams/{teamId}/reinstate',
+fetch('http://localhost:3000/api/admin/teams/{teamId}/reactivate',
 {
   method: 'POST',
 
@@ -2301,15 +2299,15 @@ fetch('http://localhost:3000/api/admin/teams/{teamId}/reinstate',
 
 ```
 
-`POST /api/admin/teams/{teamId}/reinstate`
+`POST /api/admin/teams/{teamId}/reactivate`
 
-Reinstate a previously disqualified team, allowing them to participate in the competition again.
+Reactivate a previously deactivated team, allowing them to participate in the competition again.
 
-<h3 id="reinstate-a-team-parameters">Parameters</h3>
+<h3 id="reactivate-a-team-parameters">Parameters</h3>
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|teamId|path|string|true|ID of the team to reinstate|
+|teamId|path|string|true|ID of the team to reactivate|
 
 > Example responses
 
@@ -2318,37 +2316,35 @@ Reinstate a previously disqualified team, allowing them to participate in the co
 ```json
 {
   "success": true,
-  "message": "string",
   "team": {
     "id": "string",
     "name": "string",
-    "disqualified": true
+    "active": true
   }
 }
 ```
 
-<h3 id="reinstate-a-team-responses">Responses</h3>
+<h3 id="reactivate-a-team-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Team reinstated successfully|Inline|
-|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Team is not currently disqualified|None|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Team reactivated successfully|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Team is already active|None|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized - Admin authentication required|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Team not found|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error|None|
 
-<h3 id="reinstate-a-team-responseschema">Response Schema</h3>
+<h3 id="reactivate-a-team-responseschema">Response Schema</h3>
 
 Status Code **200**
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |» success|boolean|false|none|Operation success status|
-|» message|string|false|none|Success message|
 |» team|object|false|none|none|
 |»» id|string|false|none|Team ID|
 |»» name|string|false|none|Team name|
-|»» disqualified|boolean|false|none|Disqualification status (should be false)|
+|»» active|boolean|false|none|Active status (will be true)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1389,7 +1389,8 @@ This operation does not require authentication
 const inputBody = '{
   "teamName": "Team Alpha",
   "email": "team@example.com",
-  "contactPerson": "John Doe"
+  "contactPerson": "John Doe",
+  "walletAddress": 1.0392900530713021e+47
 }';
 const headers = {
   'Content-Type':'application/json',
@@ -1421,7 +1422,8 @@ Admin-only endpoint to register a new team. Admins create team accounts and dist
 {
   "teamName": "Team Alpha",
   "email": "team@example.com",
-  "contactPerson": "John Doe"
+  "contactPerson": "John Doe",
+  "walletAddress": 1.0392900530713021e+47
 }
 ```
 
@@ -1433,6 +1435,7 @@ Admin-only endpoint to register a new team. Admins create team accounts and dist
 |» teamName|body|string|true|Name of the team|
 |» email|body|string(email)|true|Team email address|
 |» contactPerson|body|string|true|Name of the contact person|
+|» walletAddress|body|string|true|Ethereum wallet address (must start with 0x)|
 
 > Example responses
 
@@ -1447,6 +1450,7 @@ Admin-only endpoint to register a new team. Admins create team accounts and dist
     "email": "string",
     "contactPerson": "string",
     "contact_person": "string",
+    "walletAddress": "string",
     "apiKey": "abc123def456_ghi789jkl012",
     "createdAt": "2019-08-24T14:15:22Z"
   }
@@ -1458,8 +1462,8 @@ Admin-only endpoint to register a new team. Admins create team accounts and dist
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Team registered successfully|Inline|
-|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Missing required parameters|None|
-|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Team with this email already exists|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Missing required parameters or invalid wallet address|None|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Team with this email or wallet address already exists|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error|None|
 
 <h3 id="register-a-new-team-responseschema">Response Schema</h3>
@@ -1475,6 +1479,7 @@ Status Code **201**
 |»» email|string|false|none|Team email|
 |»» contactPerson|string|false|none|Contact person name|
 |»» contact_person|string|false|none|Contact person name (snake_case version)|
+|»» walletAddress|string|false|none|Ethereum wallet address|
 |»» apiKey|string|false|none|API key for the team to use with Bearer authentication. Admin should securely provide this to the team.|
 |»» createdAt|string(date-time)|false|none|Account creation timestamp|
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -783,7 +783,8 @@
                 "required": [
                   "teamName",
                   "email",
-                  "contactPerson"
+                  "contactPerson",
+                  "walletAddress"
                 ],
                 "properties": {
                   "teamName": {
@@ -801,6 +802,11 @@
                     "type": "string",
                     "description": "Name of the contact person",
                     "example": "John Doe"
+                  },
+                  "walletAddress": {
+                    "type": "string",
+                    "description": "Ethereum wallet address (must start with 0x)",
+                    "example": 1.0392900530713021e+47
                   }
                 }
               }
@@ -842,6 +848,10 @@
                           "type": "string",
                           "description": "Contact person name (snake_case version)"
                         },
+                        "walletAddress": {
+                          "type": "string",
+                          "description": "Ethereum wallet address"
+                        },
                         "apiKey": {
                           "type": "string",
                           "description": "API key for the team to use with Bearer authentication. Admin should securely provide this to the team.",
@@ -860,10 +870,10 @@
             }
           },
           "400": {
-            "description": "Missing required parameters"
+            "description": "Missing required parameters or invalid wallet address"
           },
           "409": {
-            "description": "Team with this email already exists"
+            "description": "Team with this email or wallet address already exists"
           },
           "500": {
             "description": "Server error"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1447,6 +1447,190 @@
         }
       }
     },
+    "/api/admin/teams/{teamId}/disqualify": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Disqualify a team",
+        "description": "Disqualify a team from the competition. The team will no longer be able to perform any actions.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "teamId",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "ID of the team to disqualify"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "reason"
+                ],
+                "properties": {
+                  "reason": {
+                    "type": "string",
+                    "description": "Reason for disqualification",
+                    "example": "Violated competition rules by using external API"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Team disqualified successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Success message"
+                    },
+                    "team": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Team ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Team name"
+                        },
+                        "disqualified": {
+                          "type": "boolean",
+                          "description": "Disqualification status"
+                        },
+                        "disqualificationReason": {
+                          "type": "string",
+                          "description": "Reason for disqualification"
+                        },
+                        "disqualificationDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Date of disqualification"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "403": {
+            "description": "Cannot disqualify admin accounts"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/teams/{teamId}/reinstate": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Reinstate a team",
+        "description": "Reinstate a previously disqualified team, allowing them to participate in the competition again.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "teamId",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "ID of the team to reinstate"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team reinstated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Success message"
+                    },
+                    "team": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Team ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Team name"
+                        },
+                        "disqualified": {
+                          "type": "boolean",
+                          "description": "Disqualification status (should be false)"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Team is not currently disqualified"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
     "/api/competition/leaderboard": {
       "get": {
         "tags": [
@@ -1563,6 +1747,10 @@
                           }
                         }
                       }
+                    },
+                    "disqualifiedTeamsFiltered": {
+                      "type": "boolean",
+                      "description": "Indicates whether any disqualified teams were filtered out of the leaderboard results"
                     }
                   }
                 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1560,13 +1560,13 @@
         }
       }
     },
-    "/api/admin/teams/{teamId}/disqualify": {
+    "/api/admin/teams/{teamId}/deactivate": {
       "post": {
         "tags": [
           "Admin"
         ],
-        "summary": "Disqualify a team",
-        "description": "Disqualify a team from the competition. The team will no longer be able to perform any actions.",
+        "summary": "Deactivate a team",
+        "description": "Deactivate a team from the competition. The team will no longer be able to perform any actions.",
         "security": [
           {
             "BearerAuth": []
@@ -1580,7 +1580,7 @@
               "type": "string"
             },
             "required": true,
-            "description": "ID of the team to disqualify"
+            "description": "ID of the team to deactivate"
           }
         ],
         "requestBody": {
@@ -1595,7 +1595,7 @@
                 "properties": {
                   "reason": {
                     "type": "string",
-                    "description": "Reason for disqualification",
+                    "description": "Reason for deactivation",
                     "example": "Violated competition rules by using external API"
                   }
                 }
@@ -1605,7 +1605,7 @@
         },
         "responses": {
           "200": {
-            "description": "Team disqualified successfully",
+            "description": "Team deactivated successfully",
             "content": {
               "application/json": {
                 "schema": {
@@ -1614,10 +1614,6 @@
                     "success": {
                       "type": "boolean",
                       "description": "Operation success status"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "Success message"
                     },
                     "team": {
                       "type": "object",
@@ -1630,18 +1626,18 @@
                           "type": "string",
                           "description": "Team name"
                         },
-                        "disqualified": {
+                        "active": {
                           "type": "boolean",
-                          "description": "Disqualification status"
+                          "description": "Active status (will be false)"
                         },
-                        "disqualificationReason": {
+                        "deactivationReason": {
                           "type": "string",
-                          "description": "Reason for disqualification"
+                          "description": "Reason for deactivation"
                         },
-                        "disqualificationDate": {
+                        "deactivationDate": {
                           "type": "string",
                           "format": "date-time",
-                          "description": "Date of disqualification"
+                          "description": "Date of deactivation"
                         }
                       }
                     }
@@ -1657,7 +1653,7 @@
             "description": "Unauthorized - Admin authentication required"
           },
           "403": {
-            "description": "Cannot disqualify admin accounts"
+            "description": "Cannot deactivate admin accounts"
           },
           "404": {
             "description": "Team not found"
@@ -1668,13 +1664,13 @@
         }
       }
     },
-    "/api/admin/teams/{teamId}/reinstate": {
+    "/api/admin/teams/{teamId}/reactivate": {
       "post": {
         "tags": [
           "Admin"
         ],
-        "summary": "Reinstate a team",
-        "description": "Reinstate a previously disqualified team, allowing them to participate in the competition again.",
+        "summary": "Reactivate a team",
+        "description": "Reactivate a previously deactivated team, allowing them to participate in the competition again.",
         "security": [
           {
             "BearerAuth": []
@@ -1688,12 +1684,12 @@
               "type": "string"
             },
             "required": true,
-            "description": "ID of the team to reinstate"
+            "description": "ID of the team to reactivate"
           }
         ],
         "responses": {
           "200": {
-            "description": "Team reinstated successfully",
+            "description": "Team reactivated successfully",
             "content": {
               "application/json": {
                 "schema": {
@@ -1702,10 +1698,6 @@
                     "success": {
                       "type": "boolean",
                       "description": "Operation success status"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "Success message"
                     },
                     "team": {
                       "type": "object",
@@ -1718,9 +1710,9 @@
                           "type": "string",
                           "description": "Team name"
                         },
-                        "disqualified": {
+                        "active": {
                           "type": "boolean",
-                          "description": "Disqualification status (should be false)"
+                          "description": "Active status (will be true)"
                         }
                       }
                     }
@@ -1730,7 +1722,7 @@
             }
           },
           "400": {
-            "description": "Team is not currently disqualified"
+            "description": "Team is already active"
           },
           "401": {
             "description": "Unauthorized - Admin authentication required"
@@ -1858,21 +1850,21 @@
                             "type": "number",
                             "description": "Current portfolio value in USD"
                           },
-                          "disqualified": {
+                          "active": {
                             "type": "boolean",
-                            "description": "Whether the team has been disqualified"
+                            "description": "Whether the team is active"
                           },
-                          "disqualificationReason": {
+                          "deactivationReason": {
                             "type": "string",
                             "nullable": true,
-                            "description": "Reason for disqualification if applicable"
+                            "description": "Reason for deactivation if applicable"
                           }
                         }
                       }
                     },
-                    "hasDisqualifiedTeams": {
+                    "hasInactiveTeams": {
                       "type": "boolean",
-                      "description": "Indicates if any teams are disqualified"
+                      "description": "Indicates if any teams are inactive"
                     }
                   }
                 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1005,13 +1005,13 @@
         }
       }
     },
-    "/api/admin/competition/start": {
+    "/api/admin/competition/create": {
       "post": {
         "tags": [
           "Admin"
         ],
-        "summary": "Start a competition",
-        "description": "Create and start a new trading competition with specified teams",
+        "summary": "Create a competition",
+        "description": "Create a new competition without starting it. It will be in PENDING status and can be started later.",
         "security": [
           {
             "BearerAuth": []
@@ -1024,8 +1024,7 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "name",
-                  "teamIds"
+                  "name"
                 ],
                 "properties": {
                   "name": {
@@ -1036,6 +1035,107 @@
                   "description": {
                     "type": "string",
                     "description": "Competition description",
+                    "example": "A trading competition for the spring semester"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Competition created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "competition": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Competition ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Competition name"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Competition description"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "PENDING",
+                            "ACTIVE",
+                            "COMPLETED"
+                          ],
+                          "description": "Competition status"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Competition creation date"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/competition/start": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Start a competition",
+        "description": "Start a new or existing competition with specified teams. If competitionId is provided, it will start an existing competition. Otherwise, it will create and start a new one.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "teamIds"
+                ],
+                "properties": {
+                  "competitionId": {
+                    "type": "string",
+                    "description": "ID of an existing competition to start. If not provided, a new competition will be created."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Competition name (required when creating a new competition)",
+                    "example": "Spring 2023 Trading Competition"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Competition description (used when creating a new competition)",
                     "example": "A trading competition for the spring semester"
                   },
                   "teamIds": {
@@ -1091,9 +1191,9 @@
                         "status": {
                           "type": "string",
                           "enum": [
-                            "pending",
-                            "active",
-                            "completed"
+                            "PENDING",
+                            "ACTIVE",
+                            "COMPLETED"
                           ],
                           "description": "Competition status"
                         },
@@ -1116,6 +1216,9 @@
           },
           "401": {
             "description": "Unauthorized - Admin authentication required"
+          },
+          "404": {
+            "description": "Competition not found when using competitionId"
           },
           "500": {
             "description": "Server error"
@@ -1194,9 +1297,9 @@
                         "status": {
                           "type": "string",
                           "enum": [
-                            "pending",
-                            "active",
-                            "completed"
+                            "PENDING",
+                            "ACTIVE",
+                            "COMPLETED"
                           ],
                           "description": "Competition status (completed)"
                         }
@@ -1395,9 +1498,9 @@
                         "status": {
                           "type": "string",
                           "enum": [
-                            "pending",
-                            "active",
-                            "completed"
+                            "PENDING",
+                            "ACTIVE",
+                            "COMPLETED"
                           ],
                           "description": "Competition status"
                         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2002,7 +2002,7 @@
           "Competition"
         ],
         "summary": "Get competition rules",
-        "description": "Get the rules for all competitions",
+        "description": "Get the rules, rate limits, and other configuration details for the competition",
         "security": [
           {
             "BearerAuth": []
@@ -2022,7 +2022,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Competition rules",
+            "description": "Competition rules retrieved successfully",
             "content": {
               "application/json": {
                 "schema": {
@@ -2040,18 +2040,43 @@
                           "items": {
                             "type": "string"
                           },
-                          "description": "List of trading rules"
+                          "description": "List of trading rules for the competition"
                         },
                         "rateLimits": {
                           "type": "array",
                           "items": {
                             "type": "string"
                           },
-                          "description": "List of rate limits"
+                          "description": "Rate limits for API endpoints"
+                        },
+                        "availableChains": {
+                          "type": "object",
+                          "properties": {
+                            "svm": {
+                              "type": "boolean",
+                              "description": "Whether Solana (SVM) is available"
+                            },
+                            "evm": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "description": "List of available EVM chains"
+                            }
+                          }
                         },
                         "slippageFormula": {
                           "type": "string",
-                          "description": "Formula used to calculate slippage"
+                          "description": "Formula used for calculating slippage"
+                        },
+                        "portfolioSnapshots": {
+                          "type": "object",
+                          "properties": {
+                            "interval": {
+                              "type": "string",
+                              "description": "Interval between portfolio snapshots"
+                            }
+                          }
                         }
                       }
                     }
@@ -2060,8 +2085,14 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request - No active competition"
+          },
           "401": {
             "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "403": {
+            "description": "Forbidden - Team not participating in the competition"
           },
           "500": {
             "description": "Server error"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1857,13 +1857,22 @@
                           "portfolioValue": {
                             "type": "number",
                             "description": "Current portfolio value in USD"
+                          },
+                          "disqualified": {
+                            "type": "boolean",
+                            "description": "Whether the team has been disqualified"
+                          },
+                          "disqualificationReason": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Reason for disqualification if applicable"
                           }
                         }
                       }
                     },
-                    "disqualifiedTeamsFiltered": {
+                    "hasDisqualifiedTeams": {
                       "type": "boolean",
-                      "description": "Indicates whether any disqualified teams were filtered out of the leaderboard results"
+                      "description": "Indicates if any teams are disqualified"
                     }
                   }
                 }

--- a/e2e/tests/competition.test.ts
+++ b/e2e/tests/competition.test.ts
@@ -188,7 +188,7 @@ describe('Competition API', () => {
     expect(teamInLeaderboard).toBeDefined();
   });
   
-  test('teams cannot access competitions they are not part of', async () => {
+  test('teams receive basic information for competitions they are not part of', async () => {
     // Setup admin client
     const adminClient = createTestClient();
     await adminClient.loginAsAdmin(adminApiKey);
@@ -204,11 +204,18 @@ describe('Competition API', () => {
     const statusInResponse = await teamInClient.getCompetitionStatus();
     expect(statusInResponse.success).toBe(true);
     expect(statusInResponse.competition).toBeDefined();
+    expect(statusInResponse.participating).toBe(true);
     
-    // Team not in competition checks status - should show no active competition
+    // Team not in competition checks status - should show limited competition info
     const statusOutResponse = await teamOutClient.getCompetitionStatus();
     expect(statusOutResponse.success).toBe(true);
-    expect(statusOutResponse.competition).toBeNull();
+    expect(statusOutResponse.active).toBe(true);
+    expect(statusOutResponse.competition).toBeDefined();
+    expect(statusOutResponse.competition.id).toBeDefined();
+    expect(statusOutResponse.competition.name).toBeDefined();
+    expect(statusOutResponse.competition.status).toBeDefined();
+    expect(statusOutResponse.message).toBe("Your team is not participating in this competition");
+    expect(statusOutResponse.participating).toBeUndefined();
   });
   
   test('admin can access competition endpoints without being a participant', async () => {

--- a/e2e/tests/disqualification.test.ts
+++ b/e2e/tests/disqualification.test.ts
@@ -1,0 +1,322 @@
+import { registerTeamAndGetClient, cleanupTestState, startTestCompetition, ADMIN_USERNAME, ADMIN_PASSWORD, ADMIN_EMAIL, createTestClient, wait } from '../utils/test-helpers';
+import axios from 'axios';
+import { getBaseUrl } from '../utils/server';
+import { BlockchainType } from '../../src/types';
+import config from '../../src/config';
+
+describe('Team Disqualification API', () => {
+  let adminApiKey: string;
+  
+  // Clean up test state before each test
+  beforeEach(async () => {
+    await cleanupTestState();
+    
+    // Create admin account directly using the setup endpoint
+    const response = await axios.post(`${getBaseUrl()}/api/admin/setup`, {
+      username: ADMIN_USERNAME,
+      password: ADMIN_PASSWORD,
+      email: ADMIN_EMAIL
+    });
+    
+    // Store the admin API key for authentication
+    adminApiKey = response.data.admin.apiKey;
+    expect(adminApiKey).toBeDefined();
+    console.log(`Admin API key created: ${adminApiKey.substring(0, 8)}...`);
+  });
+
+  test('admin can disqualify a team', async () => {
+    // Setup admin client
+    const adminClient = createTestClient();
+    await adminClient.loginAsAdmin(adminApiKey);
+    
+    // Register a team
+    const { team } = await registerTeamAndGetClient(adminClient, 'Team to Disqualify');
+    
+    // Disqualify the team
+    const reason = 'Violated competition rules by using external API';
+    const disqualifyResponse = await adminClient.disqualifyTeam(team.id, reason);
+    
+    // Verify disqualification response
+    expect(disqualifyResponse.success).toBe(true);
+    expect(disqualifyResponse.team).toBeDefined();
+    expect(disqualifyResponse.team.id).toBe(team.id);
+    expect(disqualifyResponse.team.name).toBe('Team to Disqualify');
+    expect(disqualifyResponse.team.disqualified).toBe(true);
+    expect(disqualifyResponse.team.disqualificationReason).toBe(reason);
+    expect(disqualifyResponse.team.disqualificationDate).toBeDefined();
+    
+    // List all teams to verify the disqualification status is persisted
+    const teamsResponse = await adminClient.listAllTeams();
+    const disqualifiedTeam = teamsResponse.teams.find((t: any) => t.id === team.id);
+    expect(disqualifiedTeam).toBeDefined();
+    expect(disqualifiedTeam.disqualified).toBe(true);
+  });
+  
+  test('disqualified team cannot access API endpoints', async () => {
+    // Setup admin client
+    const adminClient = createTestClient();
+    await adminClient.loginAsAdmin(adminApiKey);
+    
+    // Register a team and get the client
+    const { client: teamClient, team } = await registerTeamAndGetClient(adminClient, 'To Be Blocked');
+    
+    // Start a competition with the team
+    const competitionName = `Disqualification Test ${Date.now()}`;
+    await startTestCompetition(adminClient, competitionName, [team.id]);
+    
+    // Verify team can access API before disqualification
+    const profileResponse = await teamClient.getProfile();
+    expect(profileResponse.success).toBe(true);
+    
+    // Disqualify the team
+    const reason = 'Testing disqualification blocking';
+    const disqualifyResponse = await adminClient.disqualifyTeam(team.id, reason);
+    expect(disqualifyResponse.success).toBe(true);
+    
+    // Attempt to get profile - should fail with disqualification message
+    try {
+      await teamClient.getProfile();
+      // Should not reach here - access should be blocked
+      expect(false).toBe(true); // Force test to fail if we get here
+    } catch (error) {
+      // Expect error with disqualification message
+      expect(error).toBeDefined();
+      if (axios.isAxiosError(error) && error.response) {
+        expect(error.response.status).toBe(403);
+        expect(error.response.data).toBeDefined();
+        expect(error.response.data.error).toContain('disqualified');
+        expect(error.response.data.error).toContain(reason);
+      }
+    }
+    
+    // Attempt to execute a trade - should also fail with disqualification message
+    try {
+      const usdcTokenAddress = config.specificChainTokens.svm.usdc;
+      const solTokenAddress = config.specificChainTokens.svm.sol;
+      
+      await teamClient.executeTrade({
+        fromToken: usdcTokenAddress,
+        toToken: solTokenAddress,
+        amount: '100',
+        fromChain: BlockchainType.SVM,
+        toChain: BlockchainType.SVM
+      });
+      // Should not reach here - trade should be blocked
+      expect(false).toBe(true); // Force test to fail if we get here
+    } catch (error) {
+      // Expect error with disqualification message
+      expect(error).toBeDefined();
+      if (axios.isAxiosError(error) && error.response) {
+        expect(error.response.status).toBe(403);
+        expect(error.response.data).toBeDefined();
+        expect(error.response.data.error).toContain('disqualified');
+      }
+    }
+  });
+  
+  test('admin can reinstate a disqualified team', async () => {
+    // Setup admin client
+    const adminClient = createTestClient();
+    await adminClient.loginAsAdmin(adminApiKey);
+    
+    // Register a team and get the client
+    const { client: teamClient, team } = await registerTeamAndGetClient(adminClient, 'To Be Reinstated');
+    
+    // Start a competition with the team
+    const competitionName = `Reinstatement Test ${Date.now()}`;
+    await startTestCompetition(adminClient, competitionName, [team.id]);
+    
+    // Disqualify the team
+    const reason = 'Temporary disqualification for testing';
+    const disqualifyResponse = await adminClient.disqualifyTeam(team.id, reason);
+    expect(disqualifyResponse.success).toBe(true);
+    
+    // Verify team is blocked from API
+    try {
+      await teamClient.getProfile();
+      expect(false).toBe(true); // Should not succeed
+    } catch (error) {
+      expect(error).toBeDefined();
+    }
+    
+    // Reinstate the team
+    const reinstateResponse = await adminClient.reinstateTeam(team.id);
+    expect(reinstateResponse.success).toBe(true);
+    expect(reinstateResponse.team).toBeDefined();
+    expect(reinstateResponse.team.id).toBe(team.id);
+    expect(reinstateResponse.team.disqualified).toBe(false);
+    
+    // Wait a moment for any cache to update
+    await wait(100);
+    
+    // Verify team can access API after reinstatement
+    const profileResponse = await teamClient.getProfile();
+    expect(profileResponse.success).toBe(true);
+    expect(profileResponse.team.id).toBe(team.id);
+  });
+  
+  test('cannot disqualify admin accounts', async () => {
+    // Setup admin client
+    const adminClient = createTestClient();
+    await adminClient.loginAsAdmin(adminApiKey);
+    
+    // Get the list of teams to find the admin
+    const teamsResponse = await adminClient.listAllTeams();
+    expect(teamsResponse.success).toBe(true);
+    
+    // Find the admin account (might be filtered out in the API response)
+    // Since we cannot directly get the admin ID, create a test that should fail
+    // for any team that is an admin
+    
+    // Register an additional team to make sure we have at least one non-admin
+    const { team: regularTeam } = await registerTeamAndGetClient(adminClient, 'Regular Team');
+    
+    // Try to disqualify each team and check for admin protection
+    for (const team of teamsResponse.teams) {
+      // Skip the team we just created as we know it's not an admin
+      if (team.id === regularTeam.id) continue;
+      
+      const disqualifyResponse = await adminClient.disqualifyTeam(team.id, 'Attempted admin disqualification');
+      
+      // If this is an admin account, it should fail with a specific error
+      if (team.isAdmin) {
+        expect(disqualifyResponse.success).toBe(false);
+        expect(disqualifyResponse.error).toContain('admin');
+      }
+    }
+    
+    // Explicitly verify we can disqualify a regular team
+    const regularDisqualifyResponse = await adminClient.disqualifyTeam(regularTeam.id, 'Regular team disqualification');
+    expect(regularDisqualifyResponse.success).toBe(true);
+  });
+  
+  test('non-admin cannot disqualify a team', async () => {
+    // Setup admin client
+    const adminClient = createTestClient();
+    await adminClient.loginAsAdmin(adminApiKey);
+    
+    // Register two teams
+    const { client: teamClient1, team: team1 } = await registerTeamAndGetClient(adminClient, 'Team One');
+    const { team: team2 } = await registerTeamAndGetClient(adminClient, 'Team Two');
+    
+    // Start a competition with both teams
+    const competitionName = `Non-Admin Test ${Date.now()}`;
+    await startTestCompetition(adminClient, competitionName, [team1.id, team2.id]);
+    
+    // Team One tries to disqualify Team Two (should fail)
+    const disqualifyResponse = await teamClient1.disqualifyTeam(team2.id, 'Unauthorized disqualification attempt');
+    
+    // Verify the operation failed due to lack of admin rights
+    expect(disqualifyResponse.success).toBe(false);
+    expect(disqualifyResponse.error).toBeDefined();
+    
+    // Verify Team Two wasn't actually disqualified
+    const teamsResponse = await adminClient.listAllTeams();
+    const teamTwoInfo = teamsResponse.teams.find((t: any) => t.id === team2.id);
+    expect(teamTwoInfo).toBeDefined();
+    expect(teamTwoInfo.disqualified).toBeFalsy();
+  });
+  
+  test('disqualified teams are filtered from leaderboard', async () => {
+    // Setup admin client
+    const adminClient = createTestClient();
+    await adminClient.loginAsAdmin(adminApiKey);
+    
+    // Register three teams for the competition
+    const { client: teamClient1, team: team1 } = await registerTeamAndGetClient(adminClient, 'Active Team 1');
+    const { client: teamClient2, team: team2 } = await registerTeamAndGetClient(adminClient, 'Active Team 2');
+    const { client: teamClient3, team: team3 } = await registerTeamAndGetClient(adminClient, 'Disqualified Team');
+    
+    // Create competition with all three teams
+    const competitionName = `Leaderboard Test ${Date.now()}`;
+    await startTestCompetition(adminClient, competitionName, [team1.id, team2.id, team3.id]);
+    
+    // Make some trades to differentiate portfolio values
+    // We'll have team3 (to be disqualified) make some trades to put them on the leaderboard
+    const usdcTokenAddress = config.specificChainTokens.svm.usdc;
+    const solTokenAddress = config.specificChainTokens.svm.sol;
+    
+    // Have Team 3 execute a trade
+    await teamClient3.executeTrade({
+      fromToken: usdcTokenAddress,
+      toToken: solTokenAddress,
+      amount: '100',
+      fromChain: BlockchainType.SVM,
+      toChain: BlockchainType.SVM
+    });
+    
+    // Have the other teams make trades too to populate leaderboard
+    await teamClient1.executeTrade({
+      fromToken: usdcTokenAddress,
+      toToken: solTokenAddress,
+      amount: '50',
+      fromChain: BlockchainType.SVM,
+      toChain: BlockchainType.SVM
+    });
+    
+    await teamClient2.executeTrade({
+      fromToken: usdcTokenAddress,
+      toToken: solTokenAddress,
+      amount: '75',
+      fromChain: BlockchainType.SVM,
+      toChain: BlockchainType.SVM
+    });
+    
+    // Wait a moment for portfolio values to update
+    await wait(1000);
+    
+    // Check leaderboard before disqualification
+    const leaderboardBefore = await teamClient1.getLeaderboard();
+    expect(leaderboardBefore.success).toBe(true);
+    expect(leaderboardBefore.leaderboard).toBeDefined();
+    
+    // All three teams should be in the leaderboard
+    const teamIds = leaderboardBefore.leaderboard.map((entry: any) => entry.teamId);
+    expect(teamIds).toContain(team1.id);
+    expect(teamIds).toContain(team2.id);
+    expect(teamIds).toContain(team3.id);
+    
+    // Now disqualify team3
+    const reason = 'Disqualified for leaderboard test';
+    const disqualifyResponse = await adminClient.disqualifyTeam(team3.id, reason);
+    expect(disqualifyResponse.success).toBe(true);
+    
+    // Check leaderboard after disqualification
+    const leaderboardAfter = await teamClient1.getLeaderboard();
+    expect(leaderboardAfter.success).toBe(true);
+    expect(leaderboardAfter.leaderboard).toBeDefined();
+    
+    // Verify team3 is not in the leaderboard anymore
+    const teamIdsAfter = leaderboardAfter.leaderboard.map((entry: any) => entry.teamId);
+    expect(teamIdsAfter).toContain(team1.id);
+    expect(teamIdsAfter).toContain(team2.id);
+    expect(teamIdsAfter).not.toContain(team3.id);
+    
+    // Verify the disqualifiedTeamsFiltered flag is true
+    expect(leaderboardAfter.disqualifiedTeamsFiltered).toBe(true);
+    
+    // Check that rank calculation is correct (should be 1 and 2 with no gaps)
+    const ranks = leaderboardAfter.leaderboard.map((entry: any) => entry.rank);
+    expect(ranks).toEqual([1, 2]); // Should have ranks 1 and 2 only
+    
+    // Reinstate the team and verify they show up again
+    await adminClient.reinstateTeam(team3.id);
+    
+    // Wait a moment for any cache to update
+    await wait(100);
+    
+    // Check leaderboard after reinstatement
+    const leaderboardFinal = await teamClient1.getLeaderboard();
+    expect(leaderboardFinal.success).toBe(true);
+    expect(leaderboardFinal.leaderboard).toBeDefined();
+    
+    // Verify team3 is back in the leaderboard
+    const teamIdsFinal = leaderboardFinal.leaderboard.map((entry: any) => entry.teamId);
+    expect(teamIdsFinal).toContain(team1.id);
+    expect(teamIdsFinal).toContain(team2.id);
+    expect(teamIdsFinal).toContain(team3.id);
+    
+    // Verify the disqualifiedTeamsFiltered flag is false
+    expect(leaderboardFinal.disqualifiedTeamsFiltered).toBe(false);
+  });
+}); 

--- a/e2e/tests/disqualification.test.ts
+++ b/e2e/tests/disqualification.test.ts
@@ -286,18 +286,23 @@ describe('Team Disqualification API', () => {
     expect(leaderboardAfter.success).toBe(true);
     expect(leaderboardAfter.leaderboard).toBeDefined();
     
-    // Verify team3 is not in the leaderboard anymore
+    // Verify team3 is still in the leaderboard but marked as disqualified
     const teamIdsAfter = leaderboardAfter.leaderboard.map((entry: any) => entry.teamId);
     expect(teamIdsAfter).toContain(team1.id);
     expect(teamIdsAfter).toContain(team2.id);
-    expect(teamIdsAfter).not.toContain(team3.id);
+    expect(teamIdsAfter).toContain(team3.id);
     
-    // Verify the disqualifiedTeamsFiltered flag is true
-    expect(leaderboardAfter.disqualifiedTeamsFiltered).toBe(true);
+    // Find team3 entry and verify it's marked as disqualified
+    const team3Entry = leaderboardAfter.leaderboard.find((entry: any) => entry.teamId === team3.id);
+    expect(team3Entry).toBeDefined();
+    expect(team3Entry.disqualified).toBe(true);
+    expect(team3Entry.disqualificationReason).toBe(reason);
     
-    // Check that rank calculation is correct (should be 1 and 2 with no gaps)
+    expect(leaderboardAfter.hasDisqualifiedTeams).toBe(true);
+    
+    // All teams should still have ranks
     const ranks = leaderboardAfter.leaderboard.map((entry: any) => entry.rank);
-    expect(ranks).toEqual([1, 2]); // Should have ranks 1 and 2 only
+    expect(ranks.length).toBe(3); // All three teams still have ranks
     
     // Reinstate the team and verify they show up again
     await adminClient.reinstateTeam(team3.id);
@@ -310,13 +315,19 @@ describe('Team Disqualification API', () => {
     expect(leaderboardFinal.success).toBe(true);
     expect(leaderboardFinal.leaderboard).toBeDefined();
     
-    // Verify team3 is back in the leaderboard
+    // Verify team3 is back in the leaderboard and not disqualified
     const teamIdsFinal = leaderboardFinal.leaderboard.map((entry: any) => entry.teamId);
     expect(teamIdsFinal).toContain(team1.id);
     expect(teamIdsFinal).toContain(team2.id);
     expect(teamIdsFinal).toContain(team3.id);
     
-    // Verify the disqualifiedTeamsFiltered flag is false
-    expect(leaderboardFinal.disqualifiedTeamsFiltered).toBe(false);
+    // Find team3 entry and verify it's no longer marked as disqualified
+    const team3FinalEntry = leaderboardFinal.leaderboard.find((entry: any) => entry.teamId === team3.id);
+    expect(team3FinalEntry).toBeDefined();
+    expect(team3FinalEntry.disqualified).toBe(false);
+    expect(team3FinalEntry.disqualificationReason).toBeNull();
+    
+    // Verify the hasDisqualifiedTeams flag is false
+    expect(leaderboardFinal.hasDisqualifiedTeams).toBe(false);
   });
 }); 

--- a/e2e/tests/portfolio-snapshots.test.ts
+++ b/e2e/tests/portfolio-snapshots.test.ts
@@ -210,14 +210,14 @@ describe('Portfolio Snapshots', () => {
     // Verify the USDC value is calculated correctly
     const usdcValue = initialSnapshot.valuesByToken[usdcTokenAddress];
     expect(usdcValue.amount).toBeCloseTo(initialUsdcBalance);
-    expect(usdcValue.valueUsd).toBeCloseTo(initialUsdcBalance * usdcPrice, 2);
+    expect(usdcValue.valueUsd).toBeCloseTo(initialUsdcBalance * usdcPrice, 0);
     
     // Verify total portfolio value is the sum of all token values
     const totalValue = Object.values(initialSnapshot.valuesByToken).reduce(
       (sum: number, token: any) => sum + token.valueUsd,
       0
     );
-    expect(initialSnapshot.totalValue).toBeCloseTo(totalValue, 2);
+    expect(initialSnapshot.totalValue).toBeCloseTo(totalValue, 0);
   });
 
   // Test that the configuration is loaded correctly

--- a/e2e/utils/api-client.ts
+++ b/e2e/utils/api-client.ts
@@ -127,14 +127,38 @@ export class ApiClient {
   }
   
   /**
-   * Register a new team
+   * Generate a random Ethereum address
+   * @returns A valid Ethereum address (0x + 40 hex characters)
    */
-  async registerTeam(name: string, email: string, contactPerson: string): Promise<any> {
+  private generateRandomEthAddress(): string {
+    const chars = '0123456789abcdef';
+    let address = '0x';
+    
+    // Generate 40 random hex characters
+    for (let i = 0; i < 40; i++) {
+      address += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    
+    return address;
+  }
+
+  /**
+   * Register a new team
+   * @param name Team name
+   * @param email Team email
+   * @param contactPerson Contact person name
+   * @param walletAddress Optional Ethereum wallet address (random valid address will be generated if not provided)
+   */
+  async registerTeam(name: string, email: string, contactPerson: string, walletAddress?: string): Promise<any> {
     try {
+      // Generate a random Ethereum address if one isn't provided
+      const address = walletAddress || this.generateRandomEthAddress();
+      
       const response = await this.axiosInstance.post('/api/admin/teams/register', {
         teamName: name,
         email,
-        contactPerson
+        contactPerson,
+        walletAddress: address
       });
       
       return response.data;

--- a/e2e/utils/api-client.ts
+++ b/e2e/utils/api-client.ts
@@ -185,6 +185,38 @@ export class ApiClient {
   }
   
   /**
+   * Create a competition in PENDING state
+   */
+  async createCompetition(name: string, description?: string): Promise<any> {
+    try {
+      const response = await this.axiosInstance.post('/api/admin/competition/create', {
+        name,
+        description
+      });
+      
+      return response.data;
+    } catch (error) {
+      return this.handleApiError(error, 'create competition');
+    }
+  }
+  
+  /**
+   * Start an existing competition
+   */
+  async startExistingCompetition(competitionId: string, teamIds: string[]): Promise<any> {
+    try {
+      const response = await this.axiosInstance.post('/api/admin/competition/start', {
+        competitionId,
+        teamIds
+      });
+      
+      return response.data;
+    } catch (error) {
+      return this.handleApiError(error, 'start existing competition');
+    }
+  }
+  
+  /**
    * Create a team client with a provided API key
    */
   createTeamClient(apiKey: string): ApiClient {

--- a/e2e/utils/api-client.ts
+++ b/e2e/utils/api-client.ts
@@ -403,6 +403,35 @@ export class ApiClient {
   }
   
   /**
+   * Disqualify a team (admin only)
+   * @param teamId ID of the team to disqualify
+   * @param reason Reason for disqualification
+   */
+  async disqualifyTeam(teamId: string, reason: string): Promise<any> {
+    try {
+      const response = await this.axiosInstance.post(`/api/admin/teams/${teamId}/disqualify`, {
+        reason
+      });
+      return response.data;
+    } catch (error) {
+      return this.handleApiError(error, 'disqualify team');
+    }
+  }
+  
+  /**
+   * Reinstate a previously disqualified team (admin only)
+   * @param teamId ID of the team to reinstate
+   */
+  async reinstateTeam(teamId: string): Promise<any> {
+    try {
+      const response = await this.axiosInstance.post(`/api/admin/teams/${teamId}/reinstate`, {});
+      return response.data;
+    } catch (error) {
+      return this.handleApiError(error, 'reinstate team');
+    }
+  }
+  
+  /**
    * Generic API request method for custom endpoints
    * @param method HTTP method (get, post, put, delete)
    * @param path API path

--- a/e2e/utils/api-client.ts
+++ b/e2e/utils/api-client.ts
@@ -451,31 +451,31 @@ export class ApiClient {
   }
   
   /**
-   * Disqualify a team (admin only)
-   * @param teamId ID of the team to disqualify
-   * @param reason Reason for disqualification
+   * Deactivate a team (admin only)
+   * @param teamId ID of the team to deactivate
+   * @param reason Reason for deactivation
    */
-  async disqualifyTeam(teamId: string, reason: string): Promise<any> {
+  async deactivateTeam(teamId: string, reason: string): Promise<any> {
     try {
-      const response = await this.axiosInstance.post(`/api/admin/teams/${teamId}/disqualify`, {
+      const response = await this.axiosInstance.post(`/api/admin/teams/${teamId}/deactivate`, {
         reason
       });
       return response.data;
     } catch (error) {
-      return this.handleApiError(error, 'disqualify team');
+      return this.handleApiError(error, 'deactivate team');
     }
   }
   
   /**
-   * Reinstate a previously disqualified team (admin only)
-   * @param teamId ID of the team to reinstate
+   * Reactivate a team (admin only)
+   * @param teamId ID of the team to reactivate
    */
-  async reinstateTeam(teamId: string): Promise<any> {
+  async reactivateTeam(teamId: string): Promise<any> {
     try {
-      const response = await this.axiosInstance.post(`/api/admin/teams/${teamId}/reinstate`, {});
+      const response = await this.axiosInstance.post(`/api/admin/teams/${teamId}/reactivate`);
       return response.data;
     } catch (error) {
-      return this.handleApiError(error, 'reinstate team');
+      return this.handleApiError(error, 'reactivate team');
     }
   }
   

--- a/e2e/utils/api-client.ts
+++ b/e2e/utils/api-client.ts
@@ -45,10 +45,14 @@ export class ApiClient {
       
       // For admin routes, use admin API key if available and different from regular API key
       if (this.adminApiKey && 
-          (config.url?.startsWith('/api/admin') || config.url?.includes('admin')) && 
-          this.adminApiKey !== this.apiKey) {
-        config.headers['Authorization'] = `Bearer ${this.adminApiKey}`;
-      }
+        (
+          config.url?.startsWith('/api/admin') || 
+          config.url?.includes('admin') || 
+          config.url?.includes('competition')
+        ) && 
+        this.adminApiKey !== this.apiKey) {
+      config.headers['Authorization'] = `Bearer ${this.adminApiKey}`;
+    }
       
       // Log request (simplified)
       console.log(`[ApiClient] Request to ${config.method?.toUpperCase()} ${config.url}`);
@@ -368,6 +372,18 @@ export class ApiClient {
       return response.data;
     } catch (error) {
       return this.handleApiError(error, 'get leaderboard');
+    }
+  }
+  
+  /**
+   * Get competition rules
+   */
+  async getRules(): Promise<any> {
+    try {
+      const response = await this.axiosInstance.get('/api/competition/rules');
+      return response.data;
+    } catch (error) {
+      return this.handleApiError(error, 'get competition rules');
     }
   }
   

--- a/e2e/utils/test-helpers.ts
+++ b/e2e/utils/test-helpers.ts
@@ -79,6 +79,49 @@ export async function startTestCompetition(
 }
 
 /**
+ * Create a competition in PENDING state without starting it
+ */
+export async function createTestCompetition(
+  adminClient: ApiClient,
+  name: string,
+  description?: string
+): Promise<any> {
+  // Ensure database is initialized
+  await ensureDatabaseInitialized();
+  
+  const result = await adminClient.createCompetition(
+    name,
+    description || `Test competition description for ${name}`
+  );
+  
+  if (!result.success) {
+    throw new Error('Failed to create competition');
+  }
+  
+  return result;
+}
+
+/**
+ * Start an existing competition with given teams
+ */
+export async function startExistingTestCompetition(
+  adminClient: ApiClient,
+  competitionId: string,
+  teamIds: string[]
+): Promise<any> {
+  // Ensure database is initialized
+  await ensureDatabaseInitialized();
+  
+  const result = await adminClient.startExistingCompetition(competitionId, teamIds);
+  
+  if (!result.success) {
+    throw new Error('Failed to start existing competition');
+  }
+  
+  return result;
+}
+
+/**
  * Ensure the database is initialized before using it
  */
 async function ensureDatabaseInitialized(): Promise<void> {

--- a/scripts/register-team.ts
+++ b/scripts/register-team.ts
@@ -149,36 +149,17 @@ async function registerTeam() {
     
     safeLog(`\n${colors.blue}Registering team...${colors.reset}`);
     
-    // 1. Register the team using TeamManager to get a valid API key
-    const team = await services.teamManager.registerTeam(teamName, email, contactPerson);
-    
-    // 2. Update the team with wallet address directly in the database
-    const db = DatabaseConnection.getInstance();
-    await db.query(
-      'UPDATE teams SET wallet_address = $1 WHERE id = $2',
-      [walletAddress, team.id]
-    );
-    
-    // 3. Fetch the updated team with wallet address
-    const result = await db.query(
-      'SELECT * FROM teams WHERE id = $1',
-      [team.id]
-    );
-    
-    if (!result.rows || result.rows.length === 0) {
-      throw new Error('Failed to retrieve updated team information');
-    }
-    
-    const updatedTeam = result.rows[0];
+    // Register the team using the updated TeamManager service method
+    const team = await services.teamManager.registerTeam(teamName, email, contactPerson, walletAddress);
     
     safeLog(`\n${colors.green}✓ Team registered successfully!${colors.reset}`);
     safeLog(`\n${colors.cyan}Team Details:${colors.reset}`);
     safeLog(`${colors.cyan}----------------------------------------${colors.reset}`);
-    safeLog(`Team ID: ${updatedTeam.id}`);
-    safeLog(`Team Name: ${updatedTeam.name}`);
-    safeLog(`Email: ${updatedTeam.email}`);
-    safeLog(`Contact: ${updatedTeam.contact_person}`);
-    safeLog(`Wallet Address: ${updatedTeam.wallet_address}`);
+    safeLog(`Team ID: ${team.id}`);
+    safeLog(`Team Name: ${team.name}`);
+    safeLog(`Email: ${team.email}`);
+    safeLog(`Contact: ${team.contactPerson}`);
+    safeLog(`Wallet Address: ${team.walletAddress}`);
     safeLog(`${colors.cyan}----------------------------------------${colors.reset}`);
     
     safeLog(`\n${colors.yellow}API Credentials (SAVE THESE SECURELY):${colors.reset}`);

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -839,16 +839,16 @@ export class AdminController {
    *                       contact_person:
    *                         type: string
    *                         description: Contact person name
-   *                       disqualified:
+   *                       active:
    *                         type: boolean
-   *                         description: Disqualification status
-   *                       disqualificationReason:
+   *                         description: Active status
+   *                       deactivationReason:
    *                         type: string
-   *                         description: Reason for disqualification
-   *                       disqualificationDate:
+   *                         description: Reason for deactivation (if inactive)
+   *                       deactivationDate:
    *                         type: string
    *                         format: date-time
-   *                         description: Date of disqualification
+   *                         description: Date of deactivation (if inactive)
    *                       createdAt:
    *                         type: string
    *                         format: date-time

--- a/src/controllers/competition.controller.ts
+++ b/src/controllers/competition.controller.ts
@@ -63,7 +63,7 @@ export class CompetitionController {
    *                       description: Competition end date (null if not ended)
    *                     status:
    *                       type: string
-   *                       enum: [pending, active, completed]
+   *                       enum: [PENDING, ACTIVE, COMPLETED]
    *                       description: Competition status
    *                 leaderboard:
    *                   type: array
@@ -228,7 +228,7 @@ export class CompetitionController {
    *                       description: Competition end date (null if not ended)
    *                     status:
    *                       type: string
-   *                       enum: [pending, active, completed]
+   *                       enum: [PENDING, ACTIVE, COMPLETED]
    *                       description: Competition status
    *                 message:
    *                   type: string

--- a/src/database/init.sql
+++ b/src/database/init.sql
@@ -8,6 +8,9 @@ CREATE TABLE IF NOT EXISTS teams (
   wallet_address VARCHAR(42) UNIQUE,
   bucket_addresses TEXT[],
   is_admin BOOLEAN DEFAULT FALSE,
+  disqualified BOOLEAN DEFAULT FALSE,
+  disqualification_reason TEXT,
+  disqualification_date TIMESTAMP WITH TIME ZONE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
@@ -15,6 +18,7 @@ CREATE TABLE IF NOT EXISTS teams (
 -- Create team indexes
 CREATE INDEX IF NOT EXISTS idx_teams_api_key ON teams(api_key);
 CREATE INDEX IF NOT EXISTS idx_teams_is_admin ON teams(is_admin);
+CREATE INDEX IF NOT EXISTS idx_teams_disqualified ON teams(disqualified);
 
 -- Competitions table
 CREATE TABLE IF NOT EXISTS competitions (

--- a/src/database/init.sql
+++ b/src/database/init.sql
@@ -8,9 +8,9 @@ CREATE TABLE IF NOT EXISTS teams (
   wallet_address VARCHAR(42) UNIQUE,
   bucket_addresses TEXT[],
   is_admin BOOLEAN DEFAULT FALSE,
-  disqualified BOOLEAN DEFAULT FALSE,
-  disqualification_reason TEXT,
-  disqualification_date TIMESTAMP WITH TIME ZONE,
+  active BOOLEAN DEFAULT FALSE,
+  deactivation_reason TEXT,
+  deactivation_date TIMESTAMP WITH TIME ZONE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS teams (
 -- Create team indexes
 CREATE INDEX IF NOT EXISTS idx_teams_api_key ON teams(api_key);
 CREATE INDEX IF NOT EXISTS idx_teams_is_admin ON teams(is_admin);
-CREATE INDEX IF NOT EXISTS idx_teams_disqualified ON teams(disqualified);
+CREATE INDEX IF NOT EXISTS idx_teams_active ON teams(active);
 
 -- Competitions table
 CREATE TABLE IF NOT EXISTS competitions (

--- a/src/database/repositories/team-repository.ts
+++ b/src/database/repositories/team-repository.ts
@@ -21,9 +21,11 @@ export class TeamRepository extends BaseRepository<Team> {
     try {
       const query = `
         INSERT INTO teams (
-          id, name, email, contact_person, api_key, wallet_address, is_admin, created_at, updated_at
+          id, name, email, contact_person, api_key, wallet_address, is_admin, 
+          disqualified, disqualification_reason, disqualification_date, 
+          created_at, updated_at
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
         ) RETURNING *
       `;
       
@@ -35,6 +37,9 @@ export class TeamRepository extends BaseRepository<Team> {
         team.apiKey,
         team.walletAddress,
         team.isAdmin || false,
+        team.disqualified || false,
+        team.disqualificationReason || null,
+        team.disqualificationDate || null,
         team.createdAt,
         team.updatedAt
       ];
@@ -93,8 +98,11 @@ export class TeamRepository extends BaseRepository<Team> {
           api_key = $4,
           wallet_address = $5,
           is_admin = $6,
-          updated_at = $7
-        WHERE id = $8
+          disqualified = $7,
+          disqualification_reason = $8,
+          disqualification_date = $9,
+          updated_at = $10
+        WHERE id = $11
         RETURNING *
       `;
       
@@ -105,6 +113,9 @@ export class TeamRepository extends BaseRepository<Team> {
         team.apiKey,
         team.walletAddress,
         team.isAdmin || false,
+        team.disqualified || false,
+        team.disqualificationReason || null,
+        team.disqualificationDate || null,
         new Date(),
         team.id
       ];
@@ -178,6 +189,112 @@ export class TeamRepository extends BaseRepository<Team> {
   }
 
   /**
+   * Disqualify a team from competition
+   * @param teamId Team ID to disqualify
+   * @param reason Reason for disqualification
+   * @param client Optional database client for transactions
+   */
+  async disqualifyTeam(teamId: string, reason: string, client?: PoolClient): Promise<Team | null> {
+    try {
+      // First check if team exists
+      const team = await this.findById(teamId, client);
+      if (!team) {
+        return null;
+      }
+
+      const query = `
+        UPDATE teams SET
+          disqualified = true,
+          disqualification_reason = $1,
+          disqualification_date = $2,
+          updated_at = $3
+        WHERE id = $4
+        RETURNING *
+      `;
+      
+      const values = [
+        reason,
+        new Date(),
+        new Date(),
+        teamId
+      ];
+      
+      const result = client 
+        ? await client.query(query, values) 
+        : await this.db.query(query, values);
+      
+      if (result.rows.length === 0) {
+        return null;
+      }
+      
+      return this.mapToEntity(this.toCamelCase(result.rows[0]));
+    } catch (error) {
+      console.error('[TeamRepository] Error in disqualifyTeam:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Reinstate a previously disqualified team
+   * @param teamId Team ID to reinstate
+   * @param client Optional database client for transactions
+   */
+  async reinstateTeam(teamId: string, client?: PoolClient): Promise<Team | null> {
+    try {
+      const query = `
+        UPDATE teams SET
+          disqualified = false,
+          disqualification_reason = null,
+          disqualification_date = null,
+          updated_at = $1
+        WHERE id = $2
+        RETURNING *
+      `;
+      
+      const values = [
+        new Date(),
+        teamId
+      ];
+      
+      const result = client 
+        ? await client.query(query, values) 
+        : await this.db.query(query, values);
+      
+      if (result.rows.length === 0) {
+        return null;
+      }
+      
+      return this.mapToEntity(this.toCamelCase(result.rows[0]));
+    } catch (error) {
+      console.error('[TeamRepository] Error in reinstateTeam:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Find all disqualified teams
+   * @param client Optional database client for transactions
+   */
+  async findDisqualifiedTeams(client?: PoolClient): Promise<Team[]> {
+    try {
+      const query = `
+        SELECT * FROM teams
+        WHERE disqualified = true
+        ORDER BY disqualification_date DESC
+      `;
+      
+      const result = client 
+        ? await client.query(query) 
+        : await this.db.query(query);
+      
+      return result.rows.map((row: any) => this.mapToEntity(this.toCamelCase(row)));
+    } catch (error) {
+      console.error('[TeamRepository] Error in findDisqualifiedTeams:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Map database row to Team entity
    * @param data Row data with camelCase keys
    */
@@ -190,6 +307,9 @@ export class TeamRepository extends BaseRepository<Team> {
       apiKey: data.apiKey,
       walletAddress: data.walletAddress,
       isAdmin: data.isAdmin || false,
+      disqualified: data.disqualified || false,
+      disqualificationReason: data.disqualificationReason,
+      disqualificationDate: data.disqualificationDate ? new Date(data.disqualificationDate) : undefined,
       createdAt: new Date(data.createdAt),
       updatedAt: new Date(data.updatedAt)
     };

--- a/src/database/repositories/team-repository.ts
+++ b/src/database/repositories/team-repository.ts
@@ -21,9 +21,9 @@ export class TeamRepository extends BaseRepository<Team> {
     try {
       const query = `
         INSERT INTO teams (
-          id, name, email, contact_person, api_key, is_admin, created_at, updated_at
+          id, name, email, contact_person, api_key, wallet_address, is_admin, created_at, updated_at
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8
+          $1, $2, $3, $4, $5, $6, $7, $8, $9
         ) RETURNING *
       `;
       
@@ -33,6 +33,7 @@ export class TeamRepository extends BaseRepository<Team> {
         team.email,
         team.contactPerson,
         team.apiKey,
+        team.walletAddress,
         team.isAdmin || false,
         team.createdAt,
         team.updatedAt
@@ -90,9 +91,10 @@ export class TeamRepository extends BaseRepository<Team> {
           email = $2,
           contact_person = $3,
           api_key = $4,
-          is_admin = $5,
-          updated_at = $6
-        WHERE id = $7
+          wallet_address = $5,
+          is_admin = $6,
+          updated_at = $7
+        WHERE id = $8
         RETURNING *
       `;
       
@@ -101,6 +103,7 @@ export class TeamRepository extends BaseRepository<Team> {
         team.email,
         team.contactPerson,
         team.apiKey,
+        team.walletAddress,
         team.isAdmin || false,
         new Date(),
         team.id
@@ -185,6 +188,7 @@ export class TeamRepository extends BaseRepository<Team> {
       email: data.email,
       contactPerson: data.contactPerson,
       apiKey: data.apiKey,
+      walletAddress: data.walletAddress,
       isAdmin: data.isAdmin || false,
       createdAt: new Date(data.createdAt),
       updatedAt: new Date(data.updatedAt)

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -37,6 +37,15 @@ export const authMiddleware = (
       // Set team ID in request for use in route handlers
       req.teamId = teamId;
 
+      // Check if the team is an admin
+      const team = await teamManager.getTeam(teamId);
+      const isAdmin = team?.isAdmin === true;
+      
+      if (isAdmin) {
+        console.log(`[AuthMiddleware] Team ${teamId} is an admin, granting elevated access`);
+        req.isAdmin = true;
+      }
+
       // Check if there's an active competition
       const activeCompetition = await competitionManager.getActiveCompetition();
       
@@ -65,12 +74,13 @@ export const authMiddleware = (
   };
 };
 
-// Extend Express Request interface to include teamId and competitionId
+// Extend Express Request interface to include teamId, competitionId, and isAdmin
 declare global {
   namespace Express {
     interface Request {
       teamId?: string;
       competitionId?: string;
+      isAdmin?: boolean;
     }
   }
 } 

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -34,12 +34,12 @@ const errorHandler = (
     });
   }
   
-  // Handle disqualification errors
-  if (err.message && err.message.includes('disqualified')) {
+  // Handle inactive team errors
+  if (err.message && err.message.includes('inactive')) {
     return res.status(403).json({
       success: false,
       error: err.message,
-      disqualified: true
+      inactive: true
     });
   }
 

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -33,6 +33,15 @@ const errorHandler = (
       error: err.message
     });
   }
+  
+  // Handle disqualification errors
+  if (err.message && err.message.includes('disqualified')) {
+    return res.status(403).json({
+      success: false,
+      error: err.message,
+      disqualified: true
+    });
+  }
 
   // Handle other errors
   return res.status(500).json({

--- a/src/routes/admin.routes.ts
+++ b/src/routes/admin.routes.ts
@@ -647,12 +647,12 @@ router.get('/reports/performance', AdminController.getPerformanceReports);
 
 /**
  * @openapi
- * /api/admin/teams/{teamId}/disqualify:
+ * /api/admin/teams/{teamId}/deactivate:
  *   post:
  *     tags:
  *       - Admin
- *     summary: Disqualify a team
- *     description: Disqualify a team from the competition. The team will no longer be able to perform any actions.
+ *     summary: Deactivate a team
+ *     description: Deactivate a team from the competition. The team will no longer be able to perform any actions.
  *     security:
  *       - BearerAuth: []
  *     parameters:
@@ -661,7 +661,7 @@ router.get('/reports/performance', AdminController.getPerformanceReports);
  *         schema:
  *           type: string
  *         required: true
- *         description: ID of the team to disqualify
+ *         description: ID of the team to deactivate
  *     requestBody:
  *       required: true
  *       content:
@@ -673,11 +673,11 @@ router.get('/reports/performance', AdminController.getPerformanceReports);
  *             properties:
  *               reason:
  *                 type: string
- *                 description: Reason for disqualification
+ *                 description: Reason for deactivation
  *                 example: Violated competition rules by using external API
  *     responses:
  *       200:
- *         description: Team disqualified successfully
+ *         description: Team deactivated successfully
  *         content:
  *           application/json:
  *             schema:
@@ -686,9 +686,6 @@ router.get('/reports/performance', AdminController.getPerformanceReports);
  *                 success:
  *                   type: boolean
  *                   description: Operation success status
- *                 message:
- *                   type: string
- *                   description: Success message
  *                 team:
  *                   type: object
  *                   properties:
@@ -698,37 +695,37 @@ router.get('/reports/performance', AdminController.getPerformanceReports);
  *                     name:
  *                       type: string
  *                       description: Team name
- *                     disqualified:
+ *                     active:
  *                       type: boolean
- *                       description: Disqualification status
- *                     disqualificationReason:
+ *                       description: Active status (will be false)
+ *                     deactivationReason:
  *                       type: string
- *                       description: Reason for disqualification
- *                     disqualificationDate:
+ *                       description: Reason for deactivation
+ *                     deactivationDate:
  *                       type: string
  *                       format: date-time
- *                       description: Date of disqualification
+ *                       description: Date of deactivation
  *       400:
  *         description: Missing required parameters
  *       401:
  *         description: Unauthorized - Admin authentication required
  *       403:
- *         description: Cannot disqualify admin accounts
+ *         description: Cannot deactivate admin accounts
  *       404:
  *         description: Team not found
  *       500:
  *         description: Server error
  */
-router.post('/teams/:teamId/disqualify', AdminController.disqualifyTeam);
+router.post('/teams/:teamId/deactivate', AdminController.deactivateTeam);
 
 /**
  * @openapi
- * /api/admin/teams/{teamId}/reinstate:
+ * /api/admin/teams/{teamId}/reactivate:
  *   post:
  *     tags:
  *       - Admin
- *     summary: Reinstate a team
- *     description: Reinstate a previously disqualified team, allowing them to participate in the competition again.
+ *     summary: Reactivate a team
+ *     description: Reactivate a previously deactivated team, allowing them to participate in the competition again.
  *     security:
  *       - BearerAuth: []
  *     parameters:
@@ -737,10 +734,10 @@ router.post('/teams/:teamId/disqualify', AdminController.disqualifyTeam);
  *         schema:
  *           type: string
  *         required: true
- *         description: ID of the team to reinstate
+ *         description: ID of the team to reactivate
  *     responses:
  *       200:
- *         description: Team reinstated successfully
+ *         description: Team reactivated successfully
  *         content:
  *           application/json:
  *             schema:
@@ -749,9 +746,6 @@ router.post('/teams/:teamId/disqualify', AdminController.disqualifyTeam);
  *                 success:
  *                   type: boolean
  *                   description: Operation success status
- *                 message:
- *                   type: string
- *                   description: Success message
  *                 team:
  *                   type: object
  *                   properties:
@@ -761,11 +755,11 @@ router.post('/teams/:teamId/disqualify', AdminController.disqualifyTeam);
  *                     name:
  *                       type: string
  *                       description: Team name
- *                     disqualified:
+ *                     active:
  *                       type: boolean
- *                       description: Disqualification status (should be false)
+ *                       description: Active status (will be true)
  *       400:
- *         description: Team is not currently disqualified
+ *         description: Team is already active
  *       401:
  *         description: Unauthorized - Admin authentication required
  *       404:
@@ -773,6 +767,6 @@ router.post('/teams/:teamId/disqualify', AdminController.disqualifyTeam);
  *       500:
  *         description: Server error
  */
-router.post('/teams/:teamId/reinstate', AdminController.reinstateTeam);
+router.post('/teams/:teamId/reactivate', AdminController.reactivateTeam);
 
 export default router; 

--- a/src/routes/admin.routes.ts
+++ b/src/routes/admin.routes.ts
@@ -566,4 +566,134 @@ router.get('/competition/:competitionId/snapshots', AdminController.getCompetiti
  */
 router.get('/reports/performance', AdminController.getPerformanceReports);
 
+/**
+ * @openapi
+ * /api/admin/teams/{teamId}/disqualify:
+ *   post:
+ *     tags:
+ *       - Admin
+ *     summary: Disqualify a team
+ *     description: Disqualify a team from the competition. The team will no longer be able to perform any actions.
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: teamId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: ID of the team to disqualify
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - reason
+ *             properties:
+ *               reason:
+ *                 type: string
+ *                 description: Reason for disqualification
+ *                 example: Violated competition rules by using external API
+ *     responses:
+ *       200:
+ *         description: Team disqualified successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Operation success status
+ *                 message:
+ *                   type: string
+ *                   description: Success message
+ *                 team:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       description: Team ID
+ *                     name:
+ *                       type: string
+ *                       description: Team name
+ *                     disqualified:
+ *                       type: boolean
+ *                       description: Disqualification status
+ *                     disqualificationReason:
+ *                       type: string
+ *                       description: Reason for disqualification
+ *                     disqualificationDate:
+ *                       type: string
+ *                       format: date-time
+ *                       description: Date of disqualification
+ *       400:
+ *         description: Missing required parameters
+ *       401:
+ *         description: Unauthorized - Admin authentication required
+ *       403:
+ *         description: Cannot disqualify admin accounts
+ *       404:
+ *         description: Team not found
+ *       500:
+ *         description: Server error
+ */
+router.post('/teams/:teamId/disqualify', AdminController.disqualifyTeam);
+
+/**
+ * @openapi
+ * /api/admin/teams/{teamId}/reinstate:
+ *   post:
+ *     tags:
+ *       - Admin
+ *     summary: Reinstate a team
+ *     description: Reinstate a previously disqualified team, allowing them to participate in the competition again.
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: teamId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: ID of the team to reinstate
+ *     responses:
+ *       200:
+ *         description: Team reinstated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Operation success status
+ *                 message:
+ *                   type: string
+ *                   description: Success message
+ *                 team:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       description: Team ID
+ *                     name:
+ *                       type: string
+ *                       description: Team name
+ *                     disqualified:
+ *                       type: boolean
+ *                       description: Disqualification status (should be false)
+ *       400:
+ *         description: Team is not currently disqualified
+ *       401:
+ *         description: Unauthorized - Admin authentication required
+ *       404:
+ *         description: Team not found
+ *       500:
+ *         description: Server error
+ */
+router.post('/teams/:teamId/reinstate', AdminController.reinstateTeam);
+
 export default router; 

--- a/src/routes/admin.routes.ts
+++ b/src/routes/admin.routes.ts
@@ -100,6 +100,7 @@ router.use(adminAuthMiddleware(services.teamManager));
  *               - teamName
  *               - email
  *               - contactPerson
+ *               - walletAddress
  *             properties:
  *               teamName:
  *                 type: string
@@ -114,6 +115,10 @@ router.use(adminAuthMiddleware(services.teamManager));
  *                 type: string
  *                 description: Name of the contact person
  *                 example: John Doe
+ *               walletAddress:
+ *                 type: string
+ *                 description: Ethereum wallet address (must start with 0x)
+ *                 example: 0x1234567890123456789012345678901234567890
  *     responses:
  *       201:
  *         description: Team registered successfully
@@ -143,6 +148,9 @@ router.use(adminAuthMiddleware(services.teamManager));
  *                     contact_person:
  *                       type: string
  *                       description: Contact person name (snake_case version)
+ *                     walletAddress:
+ *                       type: string
+ *                       description: Ethereum wallet address
  *                     apiKey:
  *                       type: string
  *                       description: API key for the team to use with Bearer authentication. Admin should securely provide this to the team.
@@ -152,9 +160,9 @@ router.use(adminAuthMiddleware(services.teamManager));
  *                       format: date-time
  *                       description: Account creation timestamp
  *       400:
- *         description: Missing required parameters
+ *         description: Missing required parameters or invalid wallet address
  *       409:
- *         description: Team with this email already exists
+ *         description: Team with this email or wallet address already exists
  *       500:
  *         description: Server error
  */

--- a/src/routes/admin.routes.ts
+++ b/src/routes/admin.routes.ts
@@ -259,12 +259,12 @@ router.delete('/teams/:teamId', AdminController.deleteTeam);
 
 /**
  * @openapi
- * /api/admin/competition/start:
+ * /api/admin/competition/create:
  *   post:
  *     tags:
  *       - Admin
- *     summary: Start a competition
- *     description: Create and start a new trading competition with specified teams
+ *     summary: Create a competition
+ *     description: Create a new competition without starting it. It will be in PENDING status and can be started later.
  *     security:
  *       - BearerAuth: []
  *     requestBody:
@@ -275,7 +275,6 @@ router.delete('/teams/:teamId', AdminController.deleteTeam);
  *             type: object
  *             required:
  *               - name
- *               - teamIds
  *             properties:
  *               name:
  *                 type: string
@@ -284,6 +283,76 @@ router.delete('/teams/:teamId', AdminController.deleteTeam);
  *               description:
  *                 type: string
  *                 description: Competition description
+ *                 example: A trading competition for the spring semester
+ *     responses:
+ *       201:
+ *         description: Competition created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Operation success status
+ *                 competition:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       description: Competition ID
+ *                     name:
+ *                       type: string
+ *                       description: Competition name
+ *                     description:
+ *                       type: string
+ *                       description: Competition description
+ *                     status:
+ *                       type: string
+ *                       enum: [PENDING, ACTIVE, COMPLETED]
+ *                       description: Competition status
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *                       description: Competition creation date
+ *       400:
+ *         description: Missing required parameters
+ *       401:
+ *         description: Unauthorized - Admin authentication required
+ *       500:
+ *         description: Server error
+ */
+router.post('/competition/create', AdminController.createCompetition);
+
+/**
+ * @openapi
+ * /api/admin/competition/start:
+ *   post:
+ *     tags:
+ *       - Admin
+ *     summary: Start a competition
+ *     description: Start a new or existing competition with specified teams. If competitionId is provided, it will start an existing competition. Otherwise, it will create and start a new one.
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - teamIds
+ *             properties:
+ *               competitionId:
+ *                 type: string
+ *                 description: ID of an existing competition to start. If not provided, a new competition will be created.
+ *               name:
+ *                 type: string
+ *                 description: Competition name (required when creating a new competition)
+ *                 example: Spring 2023 Trading Competition
+ *               description:
+ *                 type: string
+ *                 description: Competition description (used when creating a new competition)
  *                 example: A trading competition for the spring semester
  *               teamIds:
  *                 type: array
@@ -324,7 +393,7 @@ router.delete('/teams/:teamId', AdminController.deleteTeam);
  *                       description: Competition end date (null if not ended)
  *                     status:
  *                       type: string
- *                       enum: [pending, active, completed]
+ *                       enum: [PENDING, ACTIVE, COMPLETED]
  *                       description: Competition status
  *                     teamIds:
  *                       type: array
@@ -335,6 +404,8 @@ router.delete('/teams/:teamId', AdminController.deleteTeam);
  *         description: Missing required parameters
  *       401:
  *         description: Unauthorized - Admin authentication required
+ *       404:
+ *         description: Competition not found when using competitionId
  *       500:
  *         description: Server error
  */
@@ -395,7 +466,7 @@ router.post('/competition/start', AdminController.startCompetition);
  *                       description: Competition end date
  *                     status:
  *                       type: string
- *                       enum: [pending, active, completed]
+ *                       enum: [PENDING, ACTIVE, COMPLETED]
  *                       description: Competition status (completed)
  *                 leaderboard:
  *                   type: array
@@ -536,7 +607,7 @@ router.get('/competition/:competitionId/snapshots', AdminController.getCompetiti
  *                       description: Competition end date
  *                     status:
  *                       type: string
- *                       enum: [pending, active, completed]
+ *                       enum: [PENDING, ACTIVE, COMPLETED]
  *                       description: Competition status
  *                 leaderboard:
  *                   type: array

--- a/src/routes/competition.routes.ts
+++ b/src/routes/competition.routes.ts
@@ -190,7 +190,7 @@ router.get('/status', CompetitionController.getStatus);
  *     tags:
  *       - Competition
  *     summary: Get competition rules
- *     description: Get the rules for all competitions
+ *     description: Get the rules, rate limits, and other configuration details for the competition
  *     security:
  *       - BearerAuth: []
  *     parameters:
@@ -203,7 +203,7 @@ router.get('/status', CompetitionController.getStatus);
  *         example: "Bearer abc123def456_ghi789jkl012"
  *     responses:
  *       200:
- *         description: Competition rules
+ *         description: Competition rules retrieved successfully
  *         content:
  *           application/json:
  *             schema:
@@ -219,17 +219,38 @@ router.get('/status', CompetitionController.getStatus);
  *                       type: array
  *                       items:
  *                         type: string
- *                       description: List of trading rules
+ *                       description: List of trading rules for the competition
  *                     rateLimits:
  *                       type: array
  *                       items:
  *                         type: string
- *                       description: List of rate limits
+ *                       description: Rate limits for API endpoints
+ *                     availableChains:
+ *                       type: object
+ *                       properties:
+ *                         svm:
+ *                           type: boolean
+ *                           description: Whether Solana (SVM) is available
+ *                         evm:
+ *                           type: array
+ *                           items:
+ *                             type: string
+ *                           description: List of available EVM chains
  *                     slippageFormula:
  *                       type: string
- *                       description: Formula used to calculate slippage
+ *                       description: Formula used for calculating slippage
+ *                     portfolioSnapshots:
+ *                       type: object
+ *                       properties:
+ *                         interval:
+ *                           type: string
+ *                           description: Interval between portfolio snapshots
+ *       400:
+ *         description: Bad request - No active competition
  *       401:
  *         description: Unauthorized - Missing or invalid authentication
+ *       403:
+ *         description: Forbidden - Team not participating in the competition
  *       500:
  *         description: Server error
  */

--- a/src/routes/competition.routes.ts
+++ b/src/routes/competition.routes.ts
@@ -89,9 +89,16 @@ const router = Router();
  *                       portfolioValue:
  *                         type: number
  *                         description: Current portfolio value in USD
- *                 disqualifiedTeamsFiltered:
+ *                       disqualified:
+ *                         type: boolean
+ *                         description: Whether the team has been disqualified 
+ *                       disqualificationReason:
+ *                         type: string
+ *                         nullable: true
+ *                         description: Reason for disqualification if applicable
+ *                 hasDisqualifiedTeams:
  *                   type: boolean
- *                   description: Indicates whether any disqualified teams were filtered out of the leaderboard results
+ *                   description: Indicates if any teams are disqualified
  *       400:
  *         description: Bad request - No active competition and no competitionId provided
  *       401:

--- a/src/routes/competition.routes.ts
+++ b/src/routes/competition.routes.ts
@@ -89,6 +89,9 @@ const router = Router();
  *                       portfolioValue:
  *                         type: number
  *                         description: Current portfolio value in USD
+ *                 disqualifiedTeamsFiltered:
+ *                   type: boolean
+ *                   description: Indicates whether any disqualified teams were filtered out of the leaderboard results
  *       400:
  *         description: Bad request - No active competition and no competitionId provided
  *       401:

--- a/src/routes/competition.routes.ts
+++ b/src/routes/competition.routes.ts
@@ -89,16 +89,16 @@ const router = Router();
  *                       portfolioValue:
  *                         type: number
  *                         description: Current portfolio value in USD
- *                       disqualified:
+ *                       active:
  *                         type: boolean
- *                         description: Whether the team has been disqualified 
- *                       disqualificationReason:
+ *                         description: Whether the team is active 
+ *                       deactivationReason:
  *                         type: string
  *                         nullable: true
- *                         description: Reason for disqualification if applicable
- *                 hasDisqualifiedTeams:
+ *                         description: Reason for deactivation if applicable
+ *                 hasInactiveTeams:
  *                   type: boolean
- *                   description: Indicates if any teams are disqualified
+ *                   description: Indicates if any teams are inactive
  *       400:
  *         description: Bad request - No active competition and no competitionId provided
  *       401:

--- a/src/services/balance-manager.service.ts
+++ b/src/services/balance-manager.service.ts
@@ -1,4 +1,4 @@
-import { Balance, BlockchainType, SpecificChain } from '../types';
+import { Balance, SpecificChain } from '../types';
 import { config } from '../config';
 import { repositories } from '../database';
 

--- a/src/services/team-manager.service.ts
+++ b/src/services/team-manager.service.ts
@@ -17,14 +17,33 @@ export class TeamManager {
   }
 
   /**
+   * Validate an Ethereum address
+   * @param address The Ethereum address to validate
+   * @returns True if the address is valid
+   */
+  private isValidEthereumAddress(address: string): boolean {
+    return /^0x[a-fA-F0-9]{40}$/.test(address);
+  }
+
+  /**
    * Register a new team
    * @param name Team name
    * @param email Contact email
    * @param contactPerson Contact person name
+   * @param walletAddress Ethereum wallet address (must start with 0x)
    * @returns The created team with API credentials
    */
-  async registerTeam(name: string, email: string, contactPerson: string): Promise<Team> {
+  async registerTeam(name: string, email: string, contactPerson: string, walletAddress: string): Promise<Team> {
     try {
+      // Validate wallet address
+      if (!walletAddress) {
+        throw new Error('Wallet address is required');
+      }
+      
+      if (!this.isValidEthereumAddress(walletAddress)) {
+        throw new Error('Invalid Ethereum address format. Must be 0x followed by 40 hex characters.');
+      }
+      
       // Generate team ID
       const id = uuidv4();
       
@@ -41,6 +60,7 @@ export class TeamManager {
         email,
         contactPerson,
         apiKey: encryptedApiKey, // Store encrypted key in database
+        walletAddress,
         createdAt: new Date(),
         updatedAt: new Date()
       };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import { Request } from 'express';
+
 /**
  * Token information interface
  */
@@ -176,4 +178,16 @@ export interface PortfolioValue {
 export interface ApiAuth {
   teamId: string;
   key: string;
+}
+
+/**
+ * Extended Request interface for authenticated requests
+ */
+export interface AuthenticatedRequest extends Request {
+  teamId?: string;
+  isAdmin?: boolean;
+  admin?: {
+    id: string;
+    name: string;
+  };
 } 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -131,9 +131,9 @@ export interface Team {
   apiKey: string;
   walletAddress: string;
   isAdmin?: boolean;
-  disqualified?: boolean;
-  disqualificationReason?: string;
-  disqualificationDate?: Date;
+  active?: boolean;
+  deactivationReason?: string;
+  deactivationDate?: Date;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -129,6 +129,9 @@ export interface Team {
   apiKey: string;
   walletAddress: string;
   isAdmin?: boolean;
+  disqualified?: boolean;
+  disqualificationReason?: string;
+  disqualificationDate?: Date;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -127,6 +127,7 @@ export interface Team {
   email: string;
   contactPerson: string;
   apiKey: string;
+  walletAddress: string;
   isAdmin?: boolean;
   createdAt: Date;
   updatedAt: Date;


### PR DESCRIPTION
# Summary


## Registration routes
- Completes support for admin team registration route by integrating required walletaddress for teams
- Also updates tests to ensure api-client automatically creates random wallet addresses for testing teams

## Disqualify and Reinstate Functionality

### Disqualification API Endpoints
- Added administrator endpoints to disqualify and reinstate teams
- Implemented reason tracking for disqualification actions
- Added timestamp tracking for when disqualification occurred

### Access Control
- Blocked disqualified teams from accessing API endpoints
- Returned clear error messages with disqualification reason
- Protected admin accounts from being disqualified
- Restricted disqualification actions to admin users only

### Leaderboard Integration
- Filtered disqualified teams from competition leaderboard
- Added disqualifiedTeamsFiltered flag to API responses for transparency
- Implemented rank recalculation to ensure sequential numbering without gaps
- Maintained consistent team sorting after disqualified teams are removed

### Comprehensive Testing
- Created end-to-end tests verifying all disqualification functionality
- Added specific test for leaderboard filtering behavior
- Tested disqualification, API access restriction, and reinstatement flows
- Verified admin-only permissions and admin account protection

### Database & Schema Updates
- Added disqualification status flags to team data model
- Stored disqualification reason and timestamp in database
- Ensured disqualification status persists across server restarts

## Competition Admin Routes

### New Competition Creation Endpoint

- Added a new POST /api/admin/competition/create endpoint that allows administrators to create competitions in the PENDING state without immediately starting them
- Implemented the createCompetition controller method in AdminController to support this functionality
- Updated OpenAPI documentation to clearly document the new endpoint

### Enhanced Competition Start Functionality

- Modified the existing POST /api/admin/competition/start endpoint to support two modes:
- Creating and starting a new competition in one operation (original behavior)
- Starting an existing competition by providing its competitionId
- Added proper validation to ensure competitions can only be started from the PENDING state

### Allows admin to access competition routes without participating in competition

- Updates to the competition controller to allow admins to successfully request and retrieve leaderboard, rules, and status

### API Documentation Improvements

- Standardized all enum values in the OpenAPI documentation to use uppercase values (PENDING, ACTIVE, COMPLETED) to match the CompetitionStatus enum
- Updated route descriptions to clearly explain the enhanced functionality

### Comprehensive Test Coverage

- Added tests for creating a competition without starting it
- Added tests for starting an existing competition
- Added validation tests to ensure competitions can't be started from an invalid state
- Maintained backward compatibility with existing tests

Fixes #11 (among other things)