### PR TITLE
feat: gate leaderboard access using env toggle with test, updated docs, and updated notation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,6 @@ ALLOW_CROSS_CHAIN_TRADING=false  # Set to false to disable trades between differ
 
 # Optional: Price fetching using our primary provider
 NOVES_API_KEY=your_noves_api_key_here
+
+# Optional: Disable ability for participants to view leaderboard activity (set true to activate)
+DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false

--- a/.env.test
+++ b/.env.test
@@ -59,3 +59,6 @@ PORTFOLIO_PRICE_FRESHNESS_MS=10000   # 10 seconds for testing environment
 
 # Cross-chain trading configuration
 ALLOW_CROSS_CHAIN_TRADING=false 
+
+# Optional: Disable ability for participants to view leaderboard activity (set true to activate)
+DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ The Multi-Chain Trading Simulator is a standalone server designed to host tradin
 - Competition management with leaderboards
 - Comprehensive API for trading and account management
 - Rate limiting and security features
-- **NEW: Chain Override Feature** - Specify the exact chain for EVM tokens to reduce API response times from seconds to milliseconds
-- **NEW: Cross-Chain Trading Controls** - Configure whether trades between different chains are allowed or restricted
+- Chain Override Feature - Specify the exact chain for EVM tokens to reduce API response times from seconds to milliseconds
+- Cross-Chain Trading Controls - Configure whether trades between different chains are allowed or restricted
+- Leaderboard Access Control - Configure whether participants can access the leaderboard or if it's restricted to administrators only
 
 ## Current Development Status
 
@@ -534,6 +535,12 @@ Below is a comprehensive list of all environment variables available in `.env.ex
 | `EVM_CHAIN_PRIORITY` | Optional | `eth,polygon,base,arbitrum` | Chain priority for price lookups (first chain checked first) |
 | `ALLOW_MOCK_PRICE_HISTORY` | Optional | `true` in dev, `false` in prod | Allow generation of mock price history data |
 
+### Competition Settings
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DISABLE_PARTICIPANT_LEADERBOARD_ACCESS` | Optional | `false` | When set to `true`, only admins can view the leaderboard while participants are blocked from access |
+
 ### Initial Token Balances
 
 | Variable | Required | Default | Description |
@@ -741,6 +748,45 @@ Snapshot data is available via the admin API endpoint:
 ```
 GET /api/admin/competition/:competitionId/snapshots
 ```
+
+## Leaderboard Access Control
+
+The trading simulator allows administrators to control whether participants can access the competition leaderboard. This feature is configurable in your `.env` file:
+
+### Admin-Only Access Mode
+
+With `DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=true`, the system will:
+- Allow only administrators to view the competition leaderboard
+- Return a 403 Forbidden error with a clear message to participants who attempt to access the leaderboard
+- Prevent participants from seeing other teams' performance until the competition is over
+
+This mode is ideal for:
+- Blind competitions where teams shouldn't know their ranking during the event
+- Reducing competitive pressure during educational events
+- Preventing teams from copying strategies based on leaderboard performance
+
+### Open Access Mode (Default)
+
+With `DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false` (the default setting), the system will:
+- Allow all participants to freely access the leaderboard
+- Let teams see their current ranking and portfolio performance in real-time
+- Create a more competitive atmosphere with visible rankings
+
+This mode is useful for:
+- Traditional competition formats where rankings are public
+- Creating a competitive environment that simulates real trading conditions
+- Events where teams can learn from seeing others' performance
+
+### Implementation
+
+Configure this option in your `.env` file after copying from `.env.example`:
+
+```
+# Set to true to disable participant access to leaderboard (false by default)
+DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false
+```
+
+When enabled, participants will receive a 403 Forbidden response with the message "Leaderboard access is currently restricted to administrators only" when attempting to access the leaderboard endpoint.
 
 ## Cross-Chain Trading Configuration
 

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -37,12 +37,29 @@ export async function setup() {
   console.log(`Looking for .env.test at: ${envTestPath}`);
   console.log(`.env.test file exists: ${envTestExists}`);
 
+  // Check if leaderboard-access test is being run by examining command line arguments
+  const args = process.argv.slice(2);
+  console.log(JSON.stringify(args), '42 setup')
+  const isLeaderboardTest = args.some(arg => 
+    arg.includes('leaderboard-access.test') || 
+    arg.includes('leaderboard-access')
+  );
+
   if (envTestExists) {
     // Save original values for debugging
     const originalBaseUsdcBalance = process.env.INITIAL_BASE_USDC_BALANCE;
+    const originalLeaderboardAccess = process.env.DISABLE_PARTICIPANT_LEADERBOARD_ACCESS;
     
-    // Force override with .env.test values
-    const result = config({ path: envTestPath, override: true });
+    // Force override with .env.test values (but don't override leaderboard setting if in leaderboard test)
+    const result = config({ 
+      path: envTestPath, 
+      override: true,
+      // Only use processEnv when running the leaderboard test
+      ...(isLeaderboardTest && {
+        // Preserve our manual setting instead of loading from .env.test
+        ignoreProcessEnv: false // This tells dotenv to use process.env as the starting point
+      })
+    });
     
     console.log(`Loaded .env.test file: ${result.parsed ? 'successfully' : 'failed'}`);
     if (result.parsed) {
@@ -52,6 +69,7 @@ export async function setup() {
       console.log('Critical variables after loading .env.test:');
       console.log(`- INITIAL_BASE_USDC_BALANCE: ${process.env.INITIAL_BASE_USDC_BALANCE} (was: ${originalBaseUsdcBalance})`);
       console.log(`- ALLOW_CROSS_CHAIN_TRADING: ${process.env.ALLOW_CROSS_CHAIN_TRADING}`);
+      console.log(`- DISABLE_PARTICIPANT_LEADERBOARD_ACCESS: ${process.env.DISABLE_PARTICIPANT_LEADERBOARD_ACCESS} (was: ${originalLeaderboardAccess})`);
     }
   } else {
     console.warn('⚠️ WARNING: .env.test file not found! Tests will use .env or default values.');
@@ -65,6 +83,10 @@ export async function setup() {
       const result = config({ path: envMainPath, override: true });
       console.log(`Loaded .env file: ${result.parsed ? 'successfully' : 'failed'}`);
     }
+  }
+  if (isLeaderboardTest) {
+    process.env.DISABLE_PARTICIPANT_LEADERBOARD_ACCESS = 'true';
+    console.log(`DISABLE_PARTICIPANT_LEADERBOARD_ACCESS set to: ${process.env.DISABLE_PARTICIPANT_LEADERBOARD_ACCESS}`);
   }
 
   // Ensure TEST_MODE is set

--- a/e2e/tests/leaderboard-access.test.ts
+++ b/e2e/tests/leaderboard-access.test.ts
@@ -1,0 +1,77 @@
+import { createTestClient, registerTeamAndGetClient, startTestCompetition, cleanupTestState, ADMIN_USERNAME, ADMIN_PASSWORD, ADMIN_EMAIL } from '../utils/test-helpers';
+import axios from 'axios';
+import { getBaseUrl } from '../utils/server';
+
+/**
+ * Leaderboard Access Control Tests
+ * 
+ * These tests verify that administrators can always access the leaderboard,
+ * while participant access can be controlled via the DISABLE_PARTICIPANT_LEADERBOARD_ACCESS
+ * environment variable.
+ * 
+ * This test suite uses server restarts to test different environment configurations.
+ */
+describe('Leaderboard Access Control', () => {
+    let adminApiKey: string;
+    
+    // Clean up test state before each test
+    beforeEach(async () => {
+        await cleanupTestState();
+
+        // Create admin account directly using the setup endpoint
+        const response = await axios.post(`${getBaseUrl()}/api/admin/setup`, {
+            username: ADMIN_USERNAME,
+            password: ADMIN_PASSWORD,
+            email: ADMIN_EMAIL
+        });
+
+        // Store the admin API key for authentication
+        adminApiKey = response.data.admin.apiKey;
+        expect(adminApiKey).toBeDefined();
+        console.log(`Admin API key created: ${adminApiKey.substring(0, 8)}...`);
+    });
+
+    /**
+     * Tests that only admins can access the leaderboard when access control is enabled
+     * Participants should be blocked from viewing the leaderboard in this case
+     */
+    test('participants cannot access leaderboard when toggle is set to true', async () => {
+        const adminClient = createTestClient();
+        await adminClient.loginAsAdmin(adminApiKey);
+
+        // Register a regular team
+        const { client: teamClient, team } = await registerTeamAndGetClient(adminClient, 'Test Team');
+
+        // Start a competition with the team
+        const competitionName = `Admin Access Test ${Date.now()}`;
+        await startTestCompetition(adminClient, competitionName, [team.id]);
+        
+        // Verify the admin can still access the leaderboard
+        const adminResponse = await adminClient.getLeaderboard();
+        expect(adminResponse.success).toBe(true);
+        expect(adminResponse.leaderboard).toBeDefined();
+        console.log('Admin successfully accessed leaderboard when toggle is true');
+        
+        // Team should not be able to access leaderboard
+        try {
+            const result = await teamClient.getLeaderboard();
+            // If we get here with a success response, the access control is not working as expected
+            if (result.success === true) {
+                console.log('ERROR: Participant was able to access leaderboard:', result);
+                expect(result.success).toBe(false); // Should have failed with access denied
+            } else {
+                // If we get a success:false response, that's also good - the API blocked access
+                console.log('Correctly blocked participant from accessing leaderboard with error:', result.error);
+                expect(result.success).toBe(false);
+            }
+        } catch (error) {
+            // Expected behavior - request should fail with authorization error
+            expect(error).toBeDefined();
+            if (axios.isAxiosError(error) && error.response) {
+                expect(error.response.status).toBe(403);
+                expect(error.response.data.error).toContain('restricted to administrators');
+            }
+            console.log('Correctly blocked participant from accessing leaderboard');
+        }
+    });
+}); 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -115,6 +115,7 @@ export const config = {
     windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || '60000', 10),
     maxRequests: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || '100', 10),
   },
+  leaderboardAccess: process.env.DISABLE_PARTICIPANT_LEADERBOARD_ACCESS === 'true',
   // Specific chain initial balances
   specificChainBalances: getSpecificChainBalances(),
   // Specific chain token addresses

--- a/src/controllers/competition.controller.ts
+++ b/src/controllers/competition.controller.ts
@@ -113,67 +113,76 @@ export class CompetitionController {
   static async getLeaderboard(req: AuthenticatedRequest, res: Response, next: NextFunction) {
     try {
       // Get active competition or use competitionId from query
-      const competitionId = req.query.competitionId as string || 
-                           (await services.competitionManager.getActiveCompetition())?.id;
-      
+      const competitionId = req.query.competitionId as string ||
+        (await services.competitionManager.getActiveCompetition())?.id;
+
       if (!competitionId) {
         throw new ApiError(400, 'No active competition and no competitionId provided');
       }
-      
+
       // Get the competition
       const competition = await services.competitionManager.getCompetition(competitionId);
       if (!competition) {
         throw new ApiError(404, 'Competition not found');
       }
-      
+
       // Check if the team is part of the competition
       const teamId = req.teamId;
-      
+
       // If no team ID, they can't be in the competition
       if (!teamId) {
         throw new ApiError(401, 'Authentication required to view leaderboard');
       }
-      
+
       // Check if user is an admin (added by auth middleware)
       const isAdmin = req.isAdmin === true;
-      
+
+      // Check if non-admin access is disabled via environment variable
+      const participantLeaderboardAccessDisabled = config.leaderboardAccess;
+
+      // If participant access is disabled and user is not an admin, deny access
+      if (participantLeaderboardAccessDisabled && !isAdmin) {
+        console.log(`[CompetitionController] Denying leaderboard access to non-admin team ${teamId} as participant access is disabled`);
+        throw new ApiError(403, 'Leaderboard access is currently restricted to administrators only');
+      }
+
       // If not an admin, verify team is part of the competition
       if (!isAdmin) {
         const isTeamInCompetition = await repositories.teamRepository.isTeamInCompetition(
-          teamId, 
+          teamId,
           competitionId
         );
-        
+
         if (!isTeamInCompetition) {
           throw new ApiError(403, 'Your team is not participating in this competition');
         }
       } else {
         console.log(`[CompetitionController] Admin ${teamId} accessing leaderboard for competition ${competitionId}`);
       }
-      
+
       // Get leaderboard
       const leaderboard = await services.competitionManager.getLeaderboard(competitionId);
-      
+
       // Get all teams (excluding admin teams)
       const teams = await services.teamManager.getAllTeams(false);
-      
+
       // Create map of all teams
       const teamMap = new Map(teams.map(team => [team.id, team]));
-      
+
       // Track teams with inactive status
       const inactiveTeamIds = new Set(
         teams
           .filter(team => team.active === false)
           .map(team => team.id)
       );
-      
+
       const hasInactiveTeams = inactiveTeamIds.size > 0;
-      
+
       // Format leaderboard with team names and active status
       const formattedLeaderboard = leaderboard.map((entry, index) => {
         const team = teamMap.get(entry.teamId);
         const isInactive = team?.active === false;
-        
+
         return {
           rank: index + 1,
           teamId: entry.teamId,
@@ -183,7 +192,7 @@ export class CompetitionController {
           deactivationReason: isInactive ? team?.deactivationReason : null
         };
       });
-      
+
       // Return the complete leaderboard with active/inactive flags
       res.status(200).json({
         success: true,
@@ -196,7 +205,7 @@ export class CompetitionController {
       next(error);
     }
   }
-  
+
   /**
    * Get status of the current competition
    * 
@@ -266,25 +275,25 @@ export class CompetitionController {
   static async getStatus(req: AuthenticatedRequest, res: Response, next: NextFunction) {
     try {
       console.log('[CompetitionController] Processing getStatus request');
-      
+
       // Get active competition
       const activeCompetition = await services.competitionManager.getActiveCompetition();
-      
+
       // Get team ID from request (if authenticated)
       const teamId = req.teamId;
-      
+
       // If not authenticated, just return basic status
       if (!teamId) {
-        const info = activeCompetition 
-          ? { 
-              id: activeCompetition.id,
-              name: activeCompetition.name, 
-              status: activeCompetition.status 
-            }
+        const info = activeCompetition
+          ? {
+            id: activeCompetition.id,
+            name: activeCompetition.name,
+            status: activeCompetition.status
+          }
           : null;
-        
+
         console.log(`[CompetitionController] Returning basic competition status (no auth)`);
-        
+
         return res.status(200).json({
           success: true,
           active: !!activeCompetition,
@@ -292,11 +301,11 @@ export class CompetitionController {
           message: "Authenticate to get full competition details"
         });
       }
-      
+
       // No active competition, return empty response
       if (!activeCompetition) {
         console.log('[CompetitionController] No active competition found');
-        
+
         return res.status(200).json({
           success: true,
           active: false,
@@ -304,22 +313,22 @@ export class CompetitionController {
           message: "No active competition found"
         });
       }
-      
+
       console.log(`[CompetitionController] Found active competition: ${activeCompetition.id}`);
-      
+
       // Check if the team is part of the competition
       const isTeamInCompetition = await repositories.teamRepository.isTeamInCompetition(
         teamId,
         activeCompetition.id
       );
-      
+
       // Check if the team is an admin
       const isAdmin = req.isAdmin === true;
-      
+
       // If team is not in competition and not an admin, return limited info
       if (!isTeamInCompetition && !isAdmin) {
         console.log(`[CompetitionController] Team ${teamId} is not in competition ${activeCompetition.id}`);
-        
+
         return res.status(200).json({
           success: true,
           active: true,
@@ -332,14 +341,14 @@ export class CompetitionController {
           message: "Your team is not participating in this competition"
         });
       }
-      
+
       // Return full competition details for participants and admins
       if (isAdmin) {
         console.log(`[CompetitionController] Admin ${teamId} accessing competition status`);
       } else {
         console.log(`[CompetitionController] Team ${teamId} is participating in competition ${activeCompetition.id}`);
       }
-      
+
       res.status(200).json({
         success: true,
         active: true,
@@ -350,7 +359,7 @@ export class CompetitionController {
       next(error);
     }
   }
-  
+
   /**
    * Get rules for the competition
    * 
@@ -416,65 +425,65 @@ export class CompetitionController {
     try {
       // Check if the team is authenticated
       const teamId = req.teamId;
-      
+
       // If no team ID, they can't be authenticated
       if (!teamId) {
         throw new ApiError(401, 'Authentication required to view competition rules');
       }
-      
+
       // Check if user is an admin (added by auth middleware)
       const isAdmin = req.isAdmin === true;
-      
+
       // If not an admin, verify team is part of the active competition
       if (!isAdmin) {
         // Get active competition
         const activeCompetition = await services.competitionManager.getActiveCompetition();
-        
+
         if (!activeCompetition) {
           throw new ApiError(400, 'No active competition');
         }
-        
+
         const isTeamInCompetition = await repositories.teamRepository.isTeamInCompetition(
           teamId,
           activeCompetition.id
         );
-        
+
         if (!isTeamInCompetition) {
           throw new ApiError(403, 'Your team is not participating in the active competition');
         }
       } else {
         console.log(`[CompetitionController] Admin ${teamId} accessing competition rules`);
       }
-      
+
       // Get available chains and tokens
       const evmChains = config.evmChains;
-      
+
       // Build initial balances description based on config
       const initialBalanceDescriptions = [];
-      
+
       // Chain-specific balances
       for (const chain of Object.keys(config.specificChainBalances)) {
         const chainBalances = config.specificChainBalances[chain as keyof typeof config.specificChainBalances];
         const tokenItems = [];
-        
+
         for (const token of Object.keys(chainBalances)) {
           const amount = chainBalances[token];
           if (amount > 0) {
             tokenItems.push(`${amount} ${token.toUpperCase()}`);
           }
         }
-        
+
         if (tokenItems.length > 0) {
           let chainName = chain;
           // Format chain name for better readability
           if (chain === 'eth') chainName = 'Ethereum';
           else if (chain === 'svm') chainName = 'Solana';
           else chainName = chain.charAt(0).toUpperCase() + chain.slice(1); // Capitalize
-          
+
           initialBalanceDescriptions.push(`${chainName}: ${tokenItems.join(', ')}`);
         }
       }
-      
+
       // Return the competition rules with actual config values
       res.status(200).json({
         success: true,

--- a/src/routes/competition.routes.ts
+++ b/src/routes/competition.routes.ts
@@ -10,7 +10,7 @@ const router = Router();
  *     tags:
  *       - Competition
  *     summary: Get competition leaderboard
- *     description: Get the leaderboard for the active competition or a specific competition
+ *     description: Get the leaderboard for the active competition or a specific competition. Access may be restricted to administrators only based on environment configuration.
  *     security:
  *       - BearerAuth: []
  *     parameters:
@@ -104,7 +104,7 @@ const router = Router();
  *       401:
  *         description: Unauthorized - Missing or invalid authentication
  *       403:
- *         description: Forbidden - Team not participating in the competition
+ *         description: Forbidden - Access denied due to permission restrictions or team not participating in the competition
  *       404:
  *         description: Competition not found
  *       500:


### PR DESCRIPTION
# Add Leaderboard Access Control Feature

This PR introduces a new feature that allows administrators to control whether participants can access the competition leaderboard.

# Key Changes

- Added new environment variable DISABLE_PARTICIPANT_LEADERBOARD_ACCESS (default: false)
- Modified the competition controller to check this setting before granting access
- Implemented proper 403 Forbidden response with informative error message
- Added an end-to-end test to verify truthy condition (tests already exist to test default mode)
- Updated README.md with documentation about the feature

## Not Included

- I did not regenerate the OpenAPI documentation as these will be quickly outdated once the other pull requests are merged

# Documentation

- Added the feature to the Key Features section
- Created a new section explaining the feature in detail
- Added the new environment variable to the Environment Variables Reference