### PR TITLE
chore: update ssl connection and ca cert verification pattern

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ PORT=3000
 NODE_ENV=development
 
 # Database Configuration
-DB_HOST=postgres
+DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres

--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,14 @@ PORT=3000
 NODE_ENV=development
 
 # Database Configuration
-DB_HOST=localhost
+DB_HOST=postgres
 DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
-DB_NAME=trading_simulator
 
 POSTGRES_URL= # optional
 DB_SSL= # optional
+DB_CA_CERT_PATH=./certs/your-certification.crt # optional
 
 # Redis Configuration
 REDIS_URL=redis://localhost:6379

--- a/.env.test
+++ b/.env.test
@@ -3,10 +3,7 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
-DB_NAME=solana_trading_simulator_test
-
-POSTGRES_URL= # optional
-DB_SSL= # optional
+DB_NAME=trading_simulator_test
 
 # Test Server Configuration
 TEST_PORT=3001

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ Thumbs.db
 .vscode/
 *.swp
 *.swo 
+
+# Certificates and sensitive files
+certs/*
+# Keep .gitkeep files to preserve empty directories
+!certs/.gitkeep 

--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ Below is a comprehensive list of all environment variables available in `.env.ex
 | `DB_PASSWORD` | Required if no URL | `postgres` | Database password when not using `POSTGRES_URL` |
 | `DB_NAME` | Required if no URL | `solana_trading_simulator` | Database name when not using `POSTGRES_URL` |
 | `DB_SSL` | Optional | `false` | Enable SSL for database connection (`true` or `false`) |
+| `DB_CA_CERT_PATH` | Optional | None | Path to CA certificate for SSL database connection (e.g., `./certs/ca-certificate.crt`) |
 
 ### Security Settings
 

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testTimeout: 60000, // 60 seconds timeout for tests to prevent premature failures
+  testTimeout: 120000, // 120 seconds timeout for tests to prevent premature failures
   rootDir: './',
   testMatch: ['**/*.test.ts'],
   setupFilesAfterEnv: ['<rootDir>/utils/test-setup.ts'],

--- a/scripts/initialize-db.ts
+++ b/scripts/initialize-db.ts
@@ -1,80 +1,6 @@
 import { DatabaseConnection } from "../src/database/connection";
 import * as fs from "fs";
 import * as path from "path";
-import { Client } from "pg";
-import { config } from "../src/config";
-
-async function ensureDatabaseExists(): Promise<void> {
-  // For Render PostgreSQL, we need to use the connection string directly if available
-  if (config.database.url) {
-    const client = new Client({
-      connectionString: config.database.url,
-      ssl: true
-    });
-    
-    try {
-      await client.connect();
-      console.log("Connected to Render PostgreSQL using connection string");
-      
-      // For managed databases like Render, database creation is typically not allowed
-      // so we'll just check if our database exists
-      const result = await client.query(
-        `SELECT EXISTS(
-          SELECT FROM pg_database WHERE datname = $1
-        );`,
-        [config.database.database]
-      );
-      
-      if (!result.rows[0].exists) {
-        console.log(`Database "${config.database.database}" does not exist. Note: On managed services like Render, you typically need to create databases through their dashboard.`);
-      } else {
-        console.log(`Database "${config.database.database}" exists.`);
-      }
-      
-    } catch (error) {
-      console.error("Error connecting to database:", error);
-      throw error;
-    } finally {
-      await client.end();
-    }
-    return;
-  }
-  
-  // Fall back to original approach for local development
-  const client = new Client({
-    host: config.database.host,
-    port: config.database.port,
-    user: config.database.username,
-    password: config.database.password,
-    database: "postgres", // Connect to default database first
-    ssl: config.database.ssl ? true : undefined
-  });
-
-  try {
-    await client.connect();
-
-    // Check if our target database exists
-    const result = await client.query(
-      `
-      SELECT EXISTS(
-        SELECT FROM pg_database WHERE datname = $1
-      );
-    `,
-      [config.database.database]
-    );
-
-    if (!result.rows[0].exists) {
-      console.log(`Creating database "${config.database.database}"...`);
-      await client.query(`CREATE DATABASE "${config.database.database}";`);
-      console.log("Database created successfully");
-    }
-  } catch (error) {
-    console.error("Error ensuring database exists:", error);
-    throw error;
-  } finally {
-    await client.end();
-  }
-}
 
 /**
  * Split the SQL initialization file into sections by comments
@@ -114,9 +40,7 @@ function splitSqlIntoSections(sql: string): string[] {
  * Creates tables and indices if they don't exist
  */
 export async function initializeDatabase(): Promise<void> {
-  // First ensure the database exists
-  await ensureDatabaseExists();
-
+  // Get the database connection
   const db = DatabaseConnection.getInstance();
 
   try {

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -1,5 +1,7 @@
 import { Pool, PoolClient } from 'pg';
 import { config } from '../config';
+import fs from 'fs';
+import path from 'path';
 
 /**
  * Database Connection Manager
@@ -10,16 +12,35 @@ export class DatabaseConnection {
   private pool: Pool;
 
   private constructor() {
+    // Configure SSL options based on config
+    const sslConfig = (() => {
+      // If SSL is disabled in config, don't use SSL
+      if (!config.database.ssl) {
+        return { ssl: undefined };
+      }
+      
+      // If a custom CA certificate path is provided, use it
+      // This allows using self-signed certs while maintaining validation
+      const caPath = process.env.DB_CA_CERT_PATH;
+      if (caPath && fs.existsSync(caPath)) {
+        return {
+          ssl: {
+            ca: fs.readFileSync(caPath).toString(),
+            rejectUnauthorized: true
+          }
+        };
+      }
+      
+      // Default secure SSL configuration (for all environments)
+      return { ssl: true };
+    })();
+
     // Check if a connection URL is provided
     if (config.database.url) {
-      // Check if this is a Render database (always requires SSL)
-      const isRenderDb = config.database.url.includes('render.com');
-      
       // Use connection URL which includes all connection parameters
       this.pool = new Pool({
         connectionString: config.database.url,
-        // Use secure SSL configuration with certificate validation
-        ssl: isRenderDb || config.database.ssl ? true : undefined
+        ...sslConfig
       });
       
       console.log('[DatabaseConnection] Connected to PostgreSQL using connection URL');
@@ -31,7 +52,7 @@ export class DatabaseConnection {
         host: config.database.host,
         port: config.database.port,
         database: config.database.database,
-        ssl: config.database.ssl ? true : undefined,
+        ...sslConfig,
         max: 20, // Maximum number of clients in the pool
         idleTimeoutMillis: 30000, // How long a client is allowed to remain idle before being closed
         connectionTimeoutMillis: 2000, // How long to wait for a connection to become available

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -1,7 +1,6 @@
 import { Pool, PoolClient } from 'pg';
 import { config } from '../config';
 import fs from 'fs';
-import path from 'path';
 
 /**
  * Database Connection Manager


### PR DESCRIPTION
# Summary

- Update Postgres pooling connection pattern to optionally include a ca certificate when DB_SSL=true
- Update .env.example and README to reflect these changes
- Refactor duplicative instantiations of PoolClient to only use `DatabaseConnection` (except for e2e db-manager where is required to create the testing database if not exists)