### PR TITLE
fix: resolve teammanager cache issue and implement updateTeam for controller use

### DIFF
--- a/src/controllers/account.controller.ts
+++ b/src/controllers/account.controller.ts
@@ -18,8 +18,8 @@ export class AccountController {
     try {
       const teamId = req.teamId as string;
 
-      // Get the team
-      const team = await repositories.teamRepository.findById(teamId);
+      // Get the team using the service
+      const team = await services.teamManager.getTeam(teamId);
 
       if (!team) {
         throw new ApiError(404, 'Team not found');
@@ -54,8 +54,8 @@ export class AccountController {
       const teamId = req.teamId as string;
       const { contactPerson, metadata } = req.body;
 
-      // Get the team
-      const team = await repositories.teamRepository.findById(teamId);
+      // Get the team using the service
+      const team = await services.teamManager.getTeam(teamId);
 
       if (!team) {
         throw new ApiError(404, 'Team not found');
@@ -71,9 +71,12 @@ export class AccountController {
         team.metadata = metadata;
       }
 
-      // Save the updated team
-      team.updatedAt = new Date();
-      const updatedTeam = await repositories.teamRepository.update(team);
+      // Use the TeamManager service instead of directly updating the repository
+      const updatedTeam = await services.teamManager.updateTeam(team);
+
+      if (!updatedTeam) {
+        throw new ApiError(500, 'Failed to update team profile');
+      }
 
       // Return the updated team profile
       res.status(200).json({

--- a/src/services/competition-manager.service.ts
+++ b/src/services/competition-manager.service.ts
@@ -131,8 +131,8 @@ export class CompetitionManager {
       // Register team in the competition
       await repositories.competitionRepository.addTeamToCompetition(competitionId, teamId);
 
-      // Activate the team using existing reactivateTeam method
-      await repositories.teamRepository.reactivateTeam(teamId);
+      // Use the team manager service to reactivate teams - this properly clears the cache
+      await services.teamManager.reactivateTeam(teamId);
       console.log(`[CompetitionManager] Activated team: ${teamId}`);
     }
 

--- a/src/services/team-manager.service.ts
+++ b/src/services/team-manager.service.ts
@@ -469,6 +469,40 @@ export class TeamManager {
   }
 
   /**
+   * Update a team's information
+   * @param team The team object with updated fields
+   * @returns The updated team or null if team not found
+   */
+  async updateTeam(team: Team): Promise<Team | null> {
+    try {
+      console.log(`[TeamManager] Updating team: ${team.id} (${team.name})`);
+
+      // Check if team exists
+      const existingTeam = await repositories.teamRepository.findById(team.id);
+      if (!existingTeam) {
+        console.log(`[TeamManager] Team not found for update: ${team.id}`);
+        return null;
+      }
+
+      // Always set updated timestamp
+      team.updatedAt = new Date();
+
+      // Save to database
+      const updatedTeam = await repositories.teamRepository.update(team);
+      if (!updatedTeam) {
+        console.log(`[TeamManager] Failed to update team: ${team.id}`);
+        return null;
+      }
+
+      console.log(`[TeamManager] Successfully updated team: ${updatedTeam.name} (${team.id})`);
+      return updatedTeam;
+    } catch (error) {
+      console.error(`[TeamManager] Error updating team ${team.id}:`, error);
+      throw new Error(`Failed to update team: ${error instanceof Error ? error.message : error}`);
+    }
+  }
+
+  /**
    * Get all inactive teams
    * @returns Array of inactive teams
    */


### PR DESCRIPTION
# Summary

- Fixes and correctly clears inactiveteamcache in team manager service by calling `teamManager.reactivateTeam(teamId)` in favor of repository call
- Coincides with an e2e test to confirm expected functionality

## Fixed Direct Repository Access

- Created a simplified updateTeam method in TeamManager service that properly routes team profile updates through the service layer instead of directly accessing the repository
- This ensures that when users update their profiles, the data remains consistent between the database and in-memory caches.