### PR TITLE
chore: allow ssl certification to be loaded via encoded environment var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ DB_PASSWORD=postgres
 POSTGRES_URL= # optional
 DB_SSL= # optional
 DB_CA_CERT_PATH=./certs/your-certification.crt # optional
+DB_CA_CERT_BASE64=LS0tLS1C... # optional
 
 # Redis Configuration
 REDIS_URL=redis://localhost:6379

--- a/README.md
+++ b/README.md
@@ -560,16 +560,38 @@ Below is a comprehensive list of all environment variables available in `.env.ex
 
 ### Database Configuration
 
-| Variable          | Required           | Default                    | Description                                                                                             |
-| ----------------- | ------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `POSTGRES_URL`    | Optional           | None                       | PostgreSQL connection string in the format `postgresql://username:password@host:port/database?ssl=true` |
-| `DB_HOST`         | Required if no URL | `localhost`                | Database host when not using `POSTGRES_URL`                                                             |
-| `DB_PORT`         | Optional           | `5432`                     | Database port when not using `POSTGRES_URL`                                                             |
-| `DB_USERNAME`     | Required if no URL | `postgres`                 | Database username when not using `POSTGRES_URL`                                                         |
-| `DB_PASSWORD`     | Required if no URL | `postgres`                 | Database password when not using `POSTGRES_URL`                                                         |
-| `DB_NAME`         | Required if no URL | `solana_trading_simulator` | Database name when not using `POSTGRES_URL`                                                             |
-| `DB_SSL`          | Optional           | `false`                    | Enable SSL for database connection (`true` or `false`)                                                  |
-| `DB_CA_CERT_PATH` | Optional           | None                       | Path to CA certificate for SSL database connection (e.g., `./certs/ca-certificate.crt`)                 |
+| Variable            | Required           | Default                    | Description                                                                                             |
+| ------------------- | ------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `POSTGRES_URL`      | Optional           | None                       | PostgreSQL connection string in the format `postgresql://username:password@host:port/database?ssl=true` |
+| `DB_HOST`           | Required if no URL | `localhost`                | Database host when not using `POSTGRES_URL`                                                             |
+| `DB_PORT`           | Optional           | `5432`                     | Database port when not using `POSTGRES_URL`                                                             |
+| `DB_USERNAME`       | Required if no URL | `postgres`                 | Database username when not using `POSTGRES_URL`                                                         |
+| `DB_PASSWORD`       | Required if no URL | `postgres`                 | Database password when not using `POSTGRES_URL`                                                         |
+| `DB_NAME`           | Required if no URL | `solana_trading_simulator` | Database name when not using `POSTGRES_URL`                                                             |
+| `DB_SSL`            | Optional           | `false`                    | Enable SSL for database connection (`true` or `false`)                                                  |
+| `DB_CA_CERT_PATH`   | Optional           | None                       | Path to CA certificate for SSL database connection (e.g., `./certs/ca-certificate.crt`)                 |
+| `DB_CA_CERT_BASE64` | Optional           | None                       | Base64-encoded CA certificate for SSL connection (alternative to using certificate file path)           |
+
+### Using Base64-Encoded Certificates for Deployment
+
+When deploying to platforms like Vercel or other serverless environments, using certificate files isn't always ideal. Instead, you can provide your SSL certificate as a base64-encoded string in an environment variable.
+
+To convert your certificate to base64 format:
+
+```bash
+# Encode the certificate to base64, removing newlines
+base64 -i ./certs/your-certificate.crt | tr -d '\n' > ./cert-base64.txt
+
+# View the encoded value (copy this to your environment variable)
+cat ./cert-base64.txt
+```
+
+Then set the environment variable in your deployment platform:
+
+- Variable name: `DB_CA_CERT_BASE64`
+- Value: The base64-encoded string from the previous step
+
+The application will automatically detect and use the base64-encoded certificate when `DB_CA_CERT_BASE64` is provided, falling back to `DB_CA_CERT_PATH` if available, or using the default SSL configuration if neither is specified.
 
 ### Security Settings
 

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -18,6 +18,17 @@ export class DatabaseConnection {
         return { ssl: undefined };
       }
 
+      // If a certificate is provided as an environment variable, use it
+      const certBase64 = process.env.DB_CA_CERT_BASE64; // Suitable for Vercel deployments
+      if (certBase64) {
+        return {
+          ssl: {
+            ca: Buffer.from(certBase64, 'base64').toString(),
+            rejectUnauthorized: true,
+          },
+        };
+      }
+
       // If a custom CA certificate path is provided, use it
       // This allows using self-signed certs while maintaining validation
       const caPath = process.env.DB_CA_CERT_PATH;


### PR DESCRIPTION
# Summary

- For Vercel deployments which build directly from this repository's main branch, we need another way to load the SSL certificate (to connect with supabase, for example)
- This loads an encoded version from the environment, and also provides instructions for how to encode 